### PR TITLE
update C code to conform to gnu17/ISO C17 w/o errors and warning

### DIFF
--- a/rogomatic/src/arms.c
+++ b/rogomatic/src/arms.c
@@ -29,8 +29,13 @@
  */
 
 # include <curses.h>
+
 # include "types.h"
 # include "globals.h"
+
+/* static declarations */
+static int hitbonus(int strength);
+static int damagebonus (int strength);
 
 /*
  * havearmor: Return Kth best armor. K should be in the range 1 to invcount.
@@ -41,9 +46,10 @@
 
 # define swap(x,y) {t=(x); (x)=(y); (y)=t;}
 
-int havearmor (k, print, rustproof)
+int
+havearmor (int k, int print, int rustproof)
 {
-  register int i, j, w, t, n=0;
+  int i, j, w, t, n=0;
   int armind[MAXINV], armval[MAXINV];
 
   /* Sort armor by armor class (best first) */
@@ -79,8 +85,8 @@ int havearmor (k, print, rustproof)
  * of remove curse and -2 for when we don't have a remove curse.
  */
 
-armorclass (i)
-int i;
+int
+armorclass (int i)
 {
   int class;
 
@@ -118,9 +124,10 @@ int i;
  *             then NONE is returned.
  */
 
-int haveweapon (k, print)
+int
+haveweapon (int k, int print)
 {
-  register int i, j, w, t, n=0;
+  int i, j, w, t, n=0;
   int weapind[MAXINV], weapval[MAXINV];
 
   for (i=0; i<invcount; ++i)
@@ -169,8 +176,8 @@ int haveweapon (k, print)
  *              high numbers.
  */
 
-weaponclass (i)
-int i;
+int
+weaponclass (int i)
 {
   int class, hitplus = 0, damplus = 0;
 
@@ -237,9 +244,10 @@ int i;
  *           then NONE is returned.
  */
 
-int havering (k, print)
+int
+havering (int k, int print)
 {
-  register int i, j, r, t, n=0;
+  int i, j, r, t, n=0;
   int ringind[MAXINV], ringval[MAXINV];
 
   for (i=0; i<invcount; ++i)
@@ -284,8 +292,8 @@ int havering (k, print)
  *            value of the ring.
  */
 
-ringclass (i)
-int i;
+int
+ringclass (int i)
 {
   int class = 0, magicplus = 0;
 
@@ -471,9 +479,10 @@ int i;
  *          then NONE is returned.
  */
 
-int havebow (k, print)
+int
+havebow (int k, int print)
 {
-  register int i, j, w, t, n=0;
+  int i, j, w, t, n=0;
   int bowind[MAXINV], bowval[MAXINV];
 
   for (i=0; i<invcount; ++i)
@@ -505,8 +514,8 @@ int havebow (k, print)
  *           hit, multiplied by 10.
  */
 
-bowclass (i)
-int i;
+int
+bowclass (int i)
 {
   int class, hitplus = 0, damplus = 0;
 
@@ -533,9 +542,10 @@ int i;
  * are cheating.  Consider arrows first if we are wielding our bow.
  */
 
-int havemissile ()
+int
+havemissile (void)
 {
-  register int i, fewest = 9999, obj = NONE;
+  int i, fewest = 9999, obj = NONE;
 
   if (wielding (thrower)) {	/* Wielding bow, use arrows */
     for (i=0; i<invcount; ++i)
@@ -569,7 +579,8 @@ int havemissile ()
  * havearrow: return the index of any arrow which has count 1.
  */
 
-havearrow ()
+int
+havearrow (void)
 {
   int arr;
 
@@ -586,8 +597,8 @@ havearrow ()
  * hitbonus: Return the bonus to hit.
  */
 
-hitbonus (strength)
-int strength;
+static int
+hitbonus(int strength)
 {
   int bonus = 0;
 
@@ -614,8 +625,8 @@ int strength;
  * damagebonus: bonus = the damage bonus.
  */
 
-damagebonus (strength)
-int strength;
+static int
+damagebonus (int strength)
 {
   int bonus = 0;
 
@@ -648,7 +659,8 @@ int strength;
  * setbonuses: Set global hit and damage pluses.
  */
 
-setbonuses ()
+void
+setbonuses(void)
 {
   /* Set global Hit bonus */
   gplushit = hitbonus (Str);

--- a/rogomatic/src/config.c
+++ b/rogomatic/src/config.c
@@ -36,7 +36,7 @@ static const char *rgmpath  = "rlog";
 static const char *lockpath = "rlog/RgmLock";
 
 const char *
-getRgmDir ()
+getRgmDir (void)
 {
   DIR *rgmdir = NULL;
 
@@ -51,7 +51,7 @@ getRgmDir ()
 }
 
 const char *
-getLockFile ()
+getLockFile (void)
 {
   DIR *rgmdir = NULL;
 

--- a/rogomatic/src/database.c
+++ b/rogomatic/src/database.c
@@ -30,13 +30,14 @@
  * Note: pack_index was first used to keep certain errors from happening.
  *       various fixes seem to have worked so it is no longer needed, but
  *       it is nice to have when dumping the table...  with that said,
- *       we do not bother to keep the pack_index reference back to the 
+ *       we do not bother to keep the pack_index reference back to the
  *       inventory accurate later on.  only new items get it set.
  *
  */
 
 # include <curses.h>
 # include <string.h>
+
 # include "types.h"
 # include "globals.h"
 
@@ -53,16 +54,19 @@ struct  {
 
 int datalen = 0;
 
+/* static declarations */
+static int findfake (char *string, stuff item_type);
+static char *realname (char *codename);
+
 /*
  * findfake: find the fakename database entry for 'string'
  *           and of item_type (both must match exactly).
  */
 
-findfake (string, item_type)
-char  *string;
-stuff item_type;
+static int
+findfake (char *string, stuff item_type)
 {
-  register int i;
+  int i;
 
   for (i = 0; i < datalen; i++)
     if (streq (dbase[i].fakename, string) &&
@@ -85,10 +89,10 @@ stuff item_type;
  * findentry: find the database entry for 'string'
  */
 
-findentry (string)
-char *string;
+int
+findentry (char *string)
 {
-  register int i;
+  int i;
 
   for (i = 0; i < datalen; i++)
     if (streq (dbase[i].fakename, string) ||
@@ -104,14 +108,13 @@ char *string;
  *     the realname.  returns pointer to the fakename or "".
  */
 
-char *findentry_getfakename (string, item_type)
-char  *string;
-stuff item_type;
+char *
+findentry_getfakename (char *string, stuff item_type)
 {
-  register int i;
+  int i;
 
   for (i = 0; i < datalen; i++)
-    if ((dbase[i].item_type == item_type) && 
+    if ((dbase[i].item_type == item_type) &&
        (streq (dbase[i].fakename, string) ||
         *dbase[i].realname && streq (dbase[i].realname, string)))
       return (dbase[i].fakename);
@@ -125,14 +128,13 @@ stuff item_type;
  *     the realname.  returns pointer to the realname or "".
  */
 
-char *findentry_getrealname (string, item_type)
-char  *string;
-stuff item_type;
+char *
+findentry_getrealname (char *string, stuff item_type)
 {
-  register int i;
+  int i;
 
   for (i = 0; i < datalen; i++)
-    if ((dbase[i].item_type == item_type) && 
+    if ((dbase[i].item_type == item_type) &&
        (streq (dbase[i].fakename, string) ||
         *dbase[i].realname && streq (dbase[i].realname, string)))
       return (dbase[i].realname);
@@ -144,10 +146,8 @@ stuff item_type;
  * addobj: Add item to dbase.
  */
 
-addobj (codename, pack_index, item_type)
-char  *codename;
-int   pack_index;
-stuff item_type;
+void
+addobj (char *codename, int pack_index, stuff item_type)
 {
   if (findfake (codename, item_type) == NOTFOUND) {
     dbase[datalen].pack_index = pack_index;
@@ -164,8 +164,8 @@ stuff item_type;
  *         object with name 'string'.
  */
 
-useobj (string)
-char *string;
+void
+useobj (char *string)
 {
   int i = findentry (string);
 
@@ -180,12 +180,10 @@ char *string;
  * light).
  */
 
-infername (codename, name, item_type)
-char  *codename;
-char  *name;
-stuff item_type;
+void
+infername (char *codename, char *name, stuff item_type)
 {
-  register int i;
+  int i;
 
   i = findfake (codename, item_type);
 
@@ -212,25 +210,25 @@ stuff item_type;
  * used: Return true if we have marked 'codename' as used.
  */
 
-int used (codename)
-char *codename;
+int
+used (char *codename)
 {
-  register int i;
+  int i;
 
   for (i = 0; i < datalen; i++)
     if (streq (dbase[i].fakename, codename))
       return (dbase[i].used);
-
+  return FALSE;
 }
 
 /*
  * know: Return true if we know what the fake name for 'name' is.
  */
 
-int know (name)
-char *name;
+int
+know (char *name)
 {
-  register int i;
+  int i;
 
   for (i = 0; i < datalen; i++)
     if (*dbase[i].realname && streq (dbase[i].realname, name))
@@ -243,10 +241,10 @@ char *name;
  * realname: Returns the real name of an object named 'codename'.
  */
 
-char *realname (codename)
-char *codename;
+static char *
+realname (char *codename)
 {
-  register int i;
+  int i;
 
   for (i = 0; i < datalen; i++)
     if (*dbase[i].realname && streq (dbase[i].fakename, codename))
@@ -259,14 +257,15 @@ char *codename;
  * dumpdatabase: Debugging, dump the database on the screen.
  */
 
-dumpdatabase ()
+void
+dumpdatabase (void)
 {
-  register int i;
+  int i;
 
   for (i = 0; i < datalen; i++) {
     at (i+1, 0);
-    printw ("%02d %c|%01d|%01d %-32s %02d '%s'", 
-      i, (dbase[i].pack_index != -1) ? LETTER(dbase[i].pack_index) : ' ', dbase[i].item_type, dbase[i].used, 
+    printw ("%02d %c|%01d|%01d %-32s %02d '%s'",
+      i, (dbase[i].pack_index != -1) ? LETTER(dbase[i].pack_index) : ' ', dbase[i].item_type, dbase[i].used,
       dbase[i].realname, i, dbase[i].fakename);
   }
 }

--- a/rogomatic/src/datesub.c
+++ b/rogomatic/src/datesub.c
@@ -1,6 +1,6 @@
-#line 2 "./lex.yy.c"
+#line 1 "./lex.yy.c"
 
-#line 4 "./lex.yy.c"
+#line 3 "./lex.yy.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -9,7 +9,7 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 1
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -47,6 +47,7 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
+typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -84,9 +85,15 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
+
+/* begin standard C++ headers. */
 
 /* TODO: this is always defined, so inline it */
 #define yyconst const
@@ -100,32 +107,26 @@ typedef unsigned int flex_uint32_t;
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart(yyin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -155,14 +156,14 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern int yyleng;
+extern yy_size_t yyleng;
 
 extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -179,7 +180,6 @@ extern FILE *yyin, *yyout;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -199,7 +199,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -261,7 +261,6 @@ static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
@@ -269,8 +268,8 @@ static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-int yyleng;
+static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
+yy_size_t yyleng;
 
 /* Points to current character in buffer. */
 static char *yy_c_buf_p = NULL;
@@ -282,62 +281,56 @@ static int yy_start = 0;	/* start state number */
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void yyensure_buffer_stack (void );
-static void yy_load_buffer_state (void );
-static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER yy_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len  );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,int len  );
-
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 #define yy_new_buffer yy_create_buffer
-
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
-
-typedef unsigned char YY_CHAR;
+typedef flex_uint8_t YY_CHAR;
 
 FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
 extern int yylineno;
-
 int yylineno = 1;
 
 extern char *yytext;
@@ -346,21 +339,20 @@ extern char *yytext;
 #endif
 #define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-static void yynoreturn yy_fatal_error (yyconst char* msg  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (int) (yy_cp - yy_bp); \
+	yyleng = (yy_size_t) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 13
 #define YY_END_OF_BUFFER 14
 /* This struct is not used in this scanner,
@@ -370,7 +362,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[36] =
+static const flex_int16_t yy_accept[36] =
     {   0,
         0,    0,   14,   13,   13,   13,   13,   13,   13,   13,
        13,   13,    0,    0,    0,    0,    0,    0,    0,    0,
@@ -378,7 +370,7 @@ static yyconst flex_int16_t yy_accept[36] =
         5,   11,   10,    9,    0
     } ;
 
-static yyconst YY_CHAR yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -410,14 +402,14 @@ static yyconst YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst YY_CHAR yy_meta[24] =
+static const YY_CHAR yy_meta[24] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1
     } ;
 
-static yyconst flex_uint16_t yy_base[37] =
+static const flex_int16_t yy_base[37] =
     {   0,
         0,    8,   40,   41,    0,   26,   25,    9,   27,   19,
        23,   21,   14,   18,   19,   18,   12,    7,    1,    5,
@@ -425,7 +417,7 @@ static yyconst flex_uint16_t yy_base[37] =
        41,   41,   41,   41,   41,    0
     } ;
 
-static yyconst flex_int16_t yy_def[37] =
+static const flex_int16_t yy_def[37] =
     {   0,
        36,   36,   35,   35,   35,   35,   35,   35,   35,   35,
        35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
@@ -433,7 +425,7 @@ static yyconst flex_int16_t yy_def[37] =
        35,   35,   35,   35,    0,   35
     } ;
 
-static yyconst flex_uint16_t yy_nxt[65] =
+static const flex_int16_t yy_nxt[65] =
     {   0,
         4,    5,    6,    7,    8,    9,   10,   11,   12,    5,
         6,    7,    8,    9,   10,   11,   12,   13,   17,   30,
@@ -444,7 +436,7 @@ static yyconst flex_uint16_t yy_nxt[65] =
        35,   35,   35,   35
     } ;
 
-static yyconst flex_int16_t yy_chk[65] =
+static const flex_int16_t yy_chk[65] =
     {   0,
        36,    1,    1,    1,    1,    1,    1,    1,    1,    2,
         2,    2,    2,    2,    2,    2,    2,    5,    8,   19,
@@ -498,7 +490,8 @@ char *yytext;
  * datesub.l:
  */
 
-#line 502 "./lex.yy.c"
+#line 493 "./lex.yy.c"
+#line 494 "./lex.yy.c"
 
 #define INITIAL 0
 
@@ -514,36 +507,36 @@ char *yytext;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * _in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * _out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-			int yyget_leng (void );
+			yy_size_t yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int _line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -551,32 +544,31 @@ void yyset_lineno (int _line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
     
-    static void yyunput (int c,char *buf_ptr  );
+    static void yyunput ( int c, char *buf_ptr  );
     
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
@@ -607,7 +599,7 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		yy_size_t n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -620,7 +612,7 @@ static int input (void );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = (int) fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -709,16 +701,16 @@ YY_DECL
 		if ( ! YY_CURRENT_BUFFER ) {
 			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer(yyin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
 	{
 #line 30 "./datesub.l"
 
-#line 722 "./lex.yy.c"
+#line 713 "./lex.yy.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -746,9 +738,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 36 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 41 );
@@ -778,69 +770,69 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 YY_RULE_SETUP
 #line 31 "./datesub.l"
-printf ("1"); 
+printf ("1");
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
 #line 32 "./datesub.l"
-printf ("2"); 
+printf ("2");
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
 #line 33 "./datesub.l"
-printf ("3"); 
+printf ("3");
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
 #line 34 "./datesub.l"
-printf ("4"); 
+printf ("4");
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
 #line 35 "./datesub.l"
-printf ("5"); 
+printf ("5");
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
 #line 36 "./datesub.l"
-printf ("6"); 
+printf ("6");
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
 #line 37 "./datesub.l"
-printf ("7"); 
+printf ("7");
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
 #line 38 "./datesub.l"
-printf ("8"); 
+printf ("8");
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
 #line 39 "./datesub.l"
-printf ("9"); 
+printf ("9");
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
 #line 40 "./datesub.l"
-printf ("10"); 
+printf ("10");
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
 #line 41 "./datesub.l"
-printf ("11"); 
+printf ("11");
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
 #line 42 "./datesub.l"
-printf ("12"); 
+printf ("12");
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
 #line 43 "./datesub.l"
 ECHO;
 	YY_BREAK
-#line 844 "./lex.yy.c"
+#line 835 "./lex.yy.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -918,7 +910,7 @@ case YY_STATE_EOF(INITIAL):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1027,7 +1019,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			int num_to_read =
+			yy_size_t num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1041,7 +1033,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				int new_size = b->yy_buf_size * 2;
+				yy_size_t new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1050,7 +1042,8 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
@@ -1082,7 +1075,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart(yyin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -1098,10 +1091,13 @@ static int yy_get_next_buffer (void)
 
 	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1134,9 +1130,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 36 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -1162,9 +1158,9 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 36 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 35);
 
 		return yy_is_jam ? 0 : yy_current_state;
@@ -1184,7 +1180,7 @@ static int yy_get_next_buffer (void)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		int number_to_move = (yy_n_chars) + 2;
+		yy_size_t number_to_move = (yy_n_chars) + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -1235,7 +1231,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			int offset = (yy_c_buf_p) - (yytext_ptr);
+			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1252,13 +1248,13 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart(yyin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap( ) )
+					if ( yywrap(  ) )
 						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
@@ -1296,11 +1292,11 @@ static int yy_get_next_buffer (void)
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer(yyin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	yy_init_buffer(YY_CURRENT_BUFFER,input_file );
-	yy_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
@@ -1328,7 +1324,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
@@ -1356,22 +1352,22 @@ static void yy_load_buffer_state  (void)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
-	b->yy_buf_size = (yy_size_t)size;
+	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
@@ -1390,9 +1386,9 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	yyfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
@@ -1404,7 +1400,7 @@ static void yy_load_buffer_state  (void)
 {
 	int oerrno = errno;
     
-	yy_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -1447,7 +1443,7 @@ static void yy_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -1478,7 +1474,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -1497,7 +1493,7 @@ void yypop_buffer_state (void)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -1507,7 +1503,7 @@ void yypop_buffer_state (void)
  */
 static void yyensure_buffer_stack (void)
 {
-	int num_to_alloc;
+	yy_size_t num_to_alloc;
     
 	if (!(yy_buffer_stack)) {
 
@@ -1564,11 +1560,11 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 		/* They forgot to leave room for the EOB's. */
 		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
 	b->yy_input_file = NULL;
@@ -1578,7 +1574,7 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
@@ -1591,10 +1587,10 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return yy_scan_bytes(yystr,(int) strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
@@ -1604,16 +1600,16 @@ YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, yy_size_t  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	int i;
+	yy_size_t i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = (yy_size_t) (_yybytes_len + 2);
-	buf = (char *) yyalloc(n  );
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -1622,7 +1618,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len )
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -1638,9 +1634,9 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len )
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yynoreturn yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-			(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -1651,7 +1647,7 @@ static void yynoreturn yy_fatal_error (yyconst char* msg )
 	do \
 		{ \
 		/* Undo effects of setting up yytext. */ \
-        int yyless_macro_arg = (n); \
+        yy_size_t yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		yytext[yyleng] = (yy_hold_char); \
 		(yy_c_buf_p) = yytext + yyless_macro_arg; \
@@ -1691,7 +1687,7 @@ FILE *yyget_out  (void)
 /** Get the length of the current token.
  * 
  */
-int yyget_leng  (void)
+yy_size_t yyget_leng  (void)
 {
         return yyleng;
 }
@@ -1775,7 +1771,7 @@ int yylex_destroy  (void)
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
 		yypop_buffer_state();
 	}
@@ -1796,7 +1792,7 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
 		
 	int i;
@@ -1806,7 +1802,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -1844,14 +1840,15 @@ void yyfree (void * ptr )
 #line 43 "./datesub.l"
 
 
-
-yywrap ()
+int
+yywrap (void)
 {
-;
+return 0;
 }
 
-main ()
+int
+main (void)
 { while (yylex ())
-    ; 
+    ;
 }
 

--- a/rogomatic/src/datesub.l
+++ b/rogomatic/src/datesub.l
@@ -28,26 +28,28 @@
 
 %}
 %%
-"Jan"				printf ("1"); 
-"Feb"				printf ("2"); 
-"Mar"				printf ("3"); 
-"Apr"				printf ("4"); 
-"May"				printf ("5"); 
-"Jun"				printf ("6"); 
-"Jul"				printf ("7"); 
-"Aug"				printf ("8"); 
-"Sep"				printf ("9"); 
-"Oct"				printf ("10"); 
-"Nov"				printf ("11"); 
-"Dec"				printf ("12"); 
+"Jan"				printf ("1");
+"Feb"				printf ("2");
+"Mar"				printf ("3");
+"Apr"				printf ("4");
+"May"				printf ("5");
+"Jun"				printf ("6");
+"Jul"				printf ("7");
+"Aug"				printf ("8");
+"Sep"				printf ("9");
+"Oct"				printf ("10");
+"Nov"				printf ("11");
+"Dec"				printf ("12");
 %%
 
-yywrap ()
+int
+yywrap (void)
 {
-;
+return 0;
 }
 
-main ()
+int
+main (void)
 { while (yylex ())
-    ; 
+    ;
 }

--- a/rogomatic/src/debuglog.c
+++ b/rogomatic/src/debuglog.c
@@ -25,7 +25,9 @@
 
 #define MAXLINE 4096
 
-FILE *debug = NULL;
+/* static declarations */
+static FILE *debug = NULL;
+static void err_doit(int errnoflag, int error, const char *fmt, va_list ap);
 
 static void
 err_doit(int errnoflag, int error, const char *fmt, va_list ap)
@@ -44,17 +46,20 @@ err_doit(int errnoflag, int error, const char *fmt, va_list ap)
   }
 }
 
-void debuglog_open (const char *log)
+void
+debuglog_open (const char *log)
 {
   debug = fopen (log, "w");
 }
 
-void debuglog_close (void)
+void
+debuglog_close (void)
 {
   fclose (debug);
 }
 
-void debuglog (const char *fmt, ...)
+void
+debuglog (const char *fmt, ...)
 {
   va_list  ap;
   char buf[MAXLINE];

--- a/rogomatic/src/findscore.c
+++ b/rogomatic/src/findscore.c
@@ -28,22 +28,29 @@
  */
 
 # include <stdio.h>
+# include <stdlib.h>
+# include <unistd.h>
+
+# include "types.h"
 # include "install.h"
+
 # define TEMPFL "/tmp/RscoreXXXXXX"
 # define ISDIGIT(c) ((c) >= '0' && (c) <= '9')
 
-findscore (rogue, roguename)
-register char *rogue, *roguename;
+int
+findscore (char *rogue, char *roguename)
 {
-  register int score, best = -1;
+  int score, best = -1;
   char cmd[100], buffer[BUFSIZ];
-  register char *s, *tmpfname = TEMPFL;
+  char *s, *tmpfname = TEMPFL;
   FILE *tmpfil;
   char tmpbuffer[256];
   snprintf (tmpbuffer, 256, "%s", tmpfname);
+  int fd;
 
   /* Run 'rogue -s', and put the scores into a temp file */
-  sprintf (cmd, "%s -s >%s", rogue, mktemp (tmpbuffer));
+  fd = mkstemp(tmpbuffer);
+  sprintf (cmd, "%s -s >%s", rogue, tmpbuffer);
   system (cmd);
 
   /* If no temp file created, return default score */

--- a/rogomatic/src/gene.c
+++ b/rogomatic/src/gene.c
@@ -29,10 +29,15 @@
 
 # include <stdio.h>
 # include <stdlib.h>
+
 # include "types.h"
 # include "install.h"
 
-int knob[MAXKNOB];
+char  genelog[100];             /* Genetic learning log file */
+char  genepool[100];            /* Gene pool */
+
+/* static declarations */
+static int knob[MAXKNOB];		/* Knobs */
 char *knob_name[MAXKNOB] = {
   "trap searching:   ",
   "door searching:   ",
@@ -44,13 +49,10 @@ char *knob_name[MAXKNOB] = {
   "hoarding food:    "
 };
 
-char genelock[100];
-char genelog[100];
-char genepool[100];
+static char  genelock[100];            /* Gene pool lock file */
 
-main (argc, argv)
-int   argc;
-char *argv[];
+int
+main (int argc, char *argv[])
 {
   int m=10, init=0, seed=0, version=RV53A, full=0;
 

--- a/rogomatic/src/globals.h
+++ b/rogomatic/src/globals.h
@@ -32,7 +32,6 @@ extern FILE *trogue;	/* From Rogue, To Rogue */
 extern FILE *logfile;		/* Rogomatic score file */
 extern FILE *realstdout;	/* Real stdout when in terse or emacs mode */
 extern FILE *snapshot;		/* File for snapshot command */
-FILE *wopen();			/* Open a file for world access */
 
 /* global characters and strings */
 extern char afterid;		/* Index of object after identify */
@@ -45,20 +44,11 @@ extern char ourkiller[];	/* What was listed on the tombstone */
 extern char *parmstr;		/* Pointer to argument space */
 extern char pending_call_letter;	/* Pack object we know a name for */
 extern char pending_call_name[];	/* Pack object name for letter */
-extern char queue[];		/* stuff to be sent to Rogue */
 extern char *roguename;		/* Name we are playing under */
 extern char screen[24][80];	/* characters drawn by Rogue */
 extern char sumline[];		/* Summation line */
 extern char *termination;	/* Latin verb for how we died */
 extern char versionstr[];	/* Version of Rogue we are playing */
-
-/* character and string functions */
-extern int getlogtoken();
-extern char *getname(), *itemstr();
-extern char logchar(), *monname(), *findentry_getfakename(), *findentry_getrealname();
-
-/* double precision floating point functions */
-double prob(), mean(), stdev();	/* For stats.c */
 
 /* global integers */
 extern int aggravated;		/* True if we aggravated this level */
@@ -66,8 +56,8 @@ extern int agoalr,agoalc;	/* where we killed a monster */
 extern int ammo;		/* Number of missiles in pack */
 extern int arglen;		/* Length of argument space */
 extern int arrowshot;		/* True if trap fired at us this round */
-extern int atrow,atcol;		/* where is the '@'? (us) */
-extern int atrow0,atcol0;	/* where was the '@' last time */
+extern int atrow, atcol;	/* where is the '@'? (us) */
+extern int atrow0, atcol0;	/* where was the '@' last time */
 extern int attempt;		/* # times have we explored this level */
 extern int badarrow;		/* True if we missed with this arrow */
 extern int beingheld;		/* True if being held by a fungus */
@@ -92,7 +82,7 @@ extern int didreadmap;		/* Last magically mapped level */
 extern int doorlist[], *newdoors; /* Holds r,c of new doors found */
 extern int doublehasted;	/* True if double hasted (3.6 only) */
 extern int droppedscare;	/* Number of scare mon. on this level */
-extern int diddrop;	/* If we've dropped anything on this spot */
+extern int diddrop;		/* If we've dropped anything on this spot */
 extern int emacs;		/* True if in emacs mode */
 extern int exploredlevel;	/* We completely explored this level */
 extern int floating;		/* True if we are levitating */
@@ -105,7 +95,7 @@ extern int goodweapon;		/* Used for two-handed sword */
 extern int gplusdam;		/* Global damage bonus */
 extern int gplushit;		/* Global hit bonus */
 extern int hasted;		/* True if hasted */
-extern int head,tail;		/* endpoints of circular queue */
+extern int head, tail;		/* endpoints of circular queue */
 extern int hitstokill;		/* Number of hits to kill last monster */
 extern int interrupted;		/* True if at commandtop from onintr() */
 extern int knowident;		/* Found an identify scroll? */
@@ -146,7 +136,7 @@ extern int room[];		/* Flags for each room */
 extern int row,col;		/* where is the cursor? */
 extern int scrmap[24][80];	/* attribute flags for squares */
 extern int slowed;		/* True if we recently slowed a monster */
-extern int stairrow,staircol;	/* Where is the staircase */
+extern int stairrow, staircol;	/* Where is the staircase */
 extern int teleported;		/* times teleported on this level */
 extern int terse;		/* True if in terse mode */
 extern int transparent;		/* True ==> user mode */
@@ -162,7 +152,7 @@ extern int zone;		/* Current zone (0 to 8) */
 extern int zonemap[9][9];	/* Connectivity map */
 
 /* Status line variables */
-extern int Level,MaxLevel,Gold,Hp,Hpmax,Str,Strmax,Ac,Exp,Explev;
+extern int Level, MaxLevel, Gold, Hp, Hpmax, Str, Strmax, Ac, Exp, Explev;
 extern char Ms[];		/* Msg 'X', 'Hungry', 'Weak', 'Fainting' */
 extern int turns;		/* Est time in Rogue turns since start */
 
@@ -199,13 +189,12 @@ extern int	ontarget, targetrow, targetcol;
 /* Monster attribute and Long term memory arrays */
 extern attrec monatt[];		/* Monster attributes */
 extern lrnrec ltm;		/* Long term memory -- general */
-extern ltmrec monhist[]; 	/* Long term memory -- creatures */
-extern ltmrec delhist[]; 	/* Long term memory -- changes this game */
+extern ltmrec monhist[];	/* Long term memory -- creatures */
+extern ltmrec delhist[];	/* Long term memory -- changes this game */
 extern int nextmon;		/* Length of LTM */
 extern int monindex[];		/* Index into monhist array */
 
 /* Genetic learning arrays */
-extern int knob[];		/* Knobs */
 extern int k_srch;		/* Propensity for searching squares */
 extern int k_door;		/* Propensity for searching doors */
 extern int k_rest;		/* Propensity for resting */

--- a/rogomatic/src/histplot.c
+++ b/rogomatic/src/histplot.c
@@ -32,6 +32,8 @@
 # include <stdlib.h>
 # include <string.h>
 
+# include "types.h"
+
 # define SKIPARG	while (*++(*argv)); --(*argv)
 
 # define BWIDTH 200
@@ -42,14 +44,16 @@
 
 int cheat = 0;
 
-main (argc, argv)
-int argc;
-char *argv[];
+/* static declarations */
+static int getscore (int *score, char *killer, int *level);
+
+int
+main (int argc, char *argv[])
 {
-  int score = 0, maxfreq = 0, lowscore = 0, min = 200, killnum = 0;
+  int score = 0, maxfreq = 0, lowscore = 0, minscore = 200, killnum = 0;
   int bucket[NUMBUK], killed[NUMBUK][NOMON], level = 0, dolev = 0;
   int total[NOMON];
-  register int i, j, h, f;
+  int i, j, h, f;
   char killer[100], plot[128];
 
   /* Zero the buckets */
@@ -69,7 +73,7 @@ char *argv[];
       switch (**argv) {
         case 'c': cheat++; break; /* List cheat games */
         case 'l': dolev++; break; /* Plot level instead of score */
-        case 'a': min = atoi (*argv+1); SKIPARG; break;
+        case 'a': minscore = atoi (*argv+1); SKIPARG; break;
         default:  printf ("Usage: histplot [-cl] [-aNNNN]\n");
           exit (1);
       }
@@ -87,7 +91,7 @@ char *argv[];
 
   /* While more scores do action for each score */
   while (getscore (&score, killer, &level) != EOF) {
-    if (score < min) { lowscore++; continue; }
+    if (score < minscore) { lowscore++; continue; }
 
     if (dolev) { h = level; }
     else       { if ((h = BUCKET(score)) >= NUMBUK) h = NUMBUK-1; }
@@ -177,14 +181,13 @@ char *argv[];
     printf ("             $ Killed by user or error\n");
 
   if (lowscore)
-    printf ("      %8d scores below %d not printed.\n", lowscore, min);
+    printf ("      %8d scores below %d not printed.\n", lowscore, minscore);
 }
 
 # define LEVELPOS 47
 
-getscore (score, killer, level)
-int *score, *level;
-char *killer;
+static int
+getscore (int *score, char *killer, int *level)
 {
   int dd, yy;
   char line[128], mmstr[8], player[16], cheated=' ';

--- a/rogomatic/src/learn.c
+++ b/rogomatic/src/learn.c
@@ -29,6 +29,9 @@
 
 # include <stdio.h>
 # include <stdlib.h>
+# include <time.h>
+# include <math.h>
+
 # include "types.h"
 
 # define TRIALS(g)		((g)->score.count)
@@ -40,13 +43,12 @@
 typedef struct {
   int   id, creation, father, mother, dna[MAXKNOB];
   statistic score, level;
-}               genotype;
+} genotype;
 
-extern int knob[];
-extern double mean(), stdev(), sqrt();
-extern FILE *wopen();
+/* static declarations */
 
-static int inittime=0, trialno=0, lastid=0;
+static time_t inittime=0;
+static int trialno=0, lastid=0;
 static int crosses=0, shifts=0, mutations=0;
 static statistic g_score = ZEROSTAT;
 static statistic g_level = ZEROSTAT;
@@ -56,47 +58,49 @@ static int mindiff = 10, pmutate = 4, pshift = 2, mintrials = 1;
 static double step = 0.33; /* standard deviations from the mean */
 static FILE *glog=NULL;
 
-static int compgene();
-static int randompool (register int m);
-static int printdna (FILE *f, register genotype *gene);
-static int summgene (register FILE *f, register genotype *gene);
-static int parsegene (register char *buf, register genotype *gene);
-static int writegene (register FILE *gfil, register genotype *g);
-static int initgene (register genotype *gene);
-static int birth (register FILE *f, register genotype *gene);
-static int cross (register int father, register int mother, register int new);
-static int mutate (register int father, register int new);
-static int shift (register int father, register int new);
-static int selectgene (register int e1, register int e2);
-static int unique (register int new);
-static int untested ();
-static int youngest ();
-static int makeunique (register int new);
-static int triangle (register int n);
-static int badgene (register int e1, register int e2);
+static int pickgenotype (void);
+static void parsegene (char *buf, genotype *gene);
+static void writegene (FILE *gfil, genotype *g);
+static void initgene (genotype *gene);
+static int compgene (const void *p1, const void *p2);
+static void summgene (FILE *f, genotype *gene);
+static void birth (FILE *f, genotype *gene);
+static void printdna (FILE *f, genotype *gene);
+static void cross (int father, int mother, int new);
+static void mutate (int father, int new);
+static void shift (int father, int new);
+static void randompool (int m);
+static int selectgene (int e1, int e2);
+static int unique (int new);
+static int untested (void);
+static int youngest (void);
+static void makeunique (int new);
+static int triangle (int n);
+static int badgene (int e1, int e2);
 
 /*
  * Start a new gene pool
  */
 
-initpool (k, m)
+void
+initpool (int k, int m)
 {
   inittime = time (0);
 
+  randompool (m);
+
   if (glog) fprintf (glog, "Gene pool initalized, k %d, m %d, %s",
                        k, m, ctime (&inittime));
-
-  randompool (m);
 }
 
 /*
  * Summarize the current gene pool
  */
 
-analyzepool (full)
-int full;
+void
+analyzepool (int full)
 {
-  register int g;
+  int g;
 
   qsort (genes, length, sizeof (*genes), compgene);
 
@@ -110,8 +114,7 @@ int full;
   /* Give average of each gene */
   if (full == 2) {
     statistic gs;
-    register int k;
-    extern char *knob_name[];
+    int k;
 
     for (k=0; k<MAXKNOB; k++) {
       clearstat (&gs);
@@ -146,10 +149,10 @@ int full;
  * setknobs: Read gene pool, pick genotype, and set knobs accordingly.
  */
 
-setknobs (newid, knb, best, avg)
-int *newid, *knb, *best, *avg;
+void
+setknobs (int *newid, int *knb, int *best, int *avg)
 {
-  register int i, g;
+  int i, g;
 
   ++trialno;
 
@@ -167,10 +170,10 @@ int *newid, *knb, *best, *avg;
  * evalknobs: Add a data point to the gene pool
  */
 
-evalknobs (gid, score, level)
-int gid, score, level;
+void
+evalknobs (int gid, int score, int level)
 {
-  register int g;
+  int g;
 
   /* Find out which gene has the correct id */
   for (g=0; g<length; g++)
@@ -200,8 +203,8 @@ int gid, score, level;
  * openlog: Open the gene log file
  */
 
-FILE *rogo_openlog (genelog)
-register char *genelog;
+FILE *
+rogo_openlog (char *genelog)
 {
   glog = wopen (genelog, "a");
   return (glog);
@@ -211,7 +214,8 @@ register char *genelog;
  * closelog: Close the log file
  */
 
-void rogo_closelog ()
+void
+rogo_closelog (void)
 {
   if (glog) fclose (glog);
 }
@@ -220,9 +224,10 @@ void rogo_closelog ()
  * pickgenotype: Run one trial, record performance, and do some learning
  */
 
-pickgenotype ()
+static int
+pickgenotype (void)
 {
-  register int youth, father, mother, new;
+  int youth, father, mother, new;
 
   /* Find genotype with fewer trials than needed to measure its performance */
   youth = untested ();
@@ -275,7 +280,7 @@ pickgenotype ()
   /* Log the birth */
   if (glog) birth (glog, genes[new]);
 
-  return (new);  		/* Evaluate the new genotype */
+  return (new);			/* Evaluate the new genotype */
 }
 
 /*
@@ -284,12 +289,12 @@ pickgenotype ()
  * if the file exists and cannot be read.
  */
 
-readgenes (genepool)
-register char *genepool;
+int
+readgenes (char *genepool)
 {
   char buf[BUFSIZ];
-  register char *b;
-  register int g=0;
+  char *b;
+  int g=0;
   FILE *gfil;
 
   if ((gfil = fopen (genepool, "r")) == NULL) {
@@ -302,7 +307,7 @@ register char *genepool;
   /* Read the header line */
   b = buf;
   fgets (b, BUFSIZ, gfil);
-  sscanf (b, "%d %d %d %d %d %d",
+  sscanf (b, "%ld %d %d %d %d %d",
           &inittime, &trialno, &lastid, &crosses, &shifts, &mutations);
   SKIPTO ('|', b);
   parsestat (b, &g_score);
@@ -329,11 +334,10 @@ register char *genepool;
  * structure, fill the structure according to the string.
  */
 
-static parsegene (buf, gene)
-register char *buf;
-register genotype *gene;
+static void
+parsegene (char *buf, genotype *gene)
 {
-  register int i;
+  int i;
 
   /* Get genotype specific info */
   sscanf (buf, "%d %d %d %d", &gene->id, &gene->creation,
@@ -361,18 +365,18 @@ register genotype *gene;
  * writegenes: Write the gene pool 'genes' out to file 'genepool'
  */
 
-writegenes (genepool)
-register char *genepool;
+void
+writegenes (char *genepool)
 {
-  register FILE *gfil;
-  register int g;
+  FILE *gfil;
+  int g;
 
   /* Open the gene file */
   if ((gfil = wopen (genepool, "w")) == NULL)
     quit (1, "Cannot open file '%s'\n", genepool);
 
   /* Write the header line */
-  fprintf (gfil, "%d %d %d %d %d %d",
+  fprintf (gfil, "%ld %d %d %d %d %d",
            inittime, trialno, lastid, crosses, shifts, mutations);
   fprintf (gfil, "|");
   writestat (gfil, &g_score);
@@ -391,11 +395,10 @@ register char *genepool;
  * Write out one line representing the gene.
  */
 
-static writegene (gfil, g)
-register FILE *gfil;
-register genotype *g;
+static void
+writegene (FILE *gfil, genotype *g)
 {
-  register int i;
+  int i;
 
   /* Print genotype specific info */
   fprintf (gfil, "%3d %4d %3d %3d|", g->id, g->creation,
@@ -421,10 +424,10 @@ register genotype *g;
  * initgene: Allocate a new genotype structure, set everything to 0.
  */
 
-static initgene (gene)
-register genotype *gene;
+static void
+initgene (genotype *gene)
 {
-  register int i;
+  int i;
 
   /* Clear genoptye specific info */
   gene->id = gene->creation = gene->father = gene->mother = 0;
@@ -441,10 +444,14 @@ register genotype *gene;
  * compgene: Compare two genotypes in terms of score.
  */
 
-static int compgene (a, b)
-genotype **a, **b;
+static int
+compgene (const void *p1, const void *p2)
 {
-  register int result;
+  int result;
+  genotype **a, **b;
+
+  a = (genotype **)p1;
+  b = (genotype **)p2;
 
   result = (int) mean (&((*b)->score)) -
            (int) mean (&((*a)->score));
@@ -457,9 +464,8 @@ genotype **a, **b;
  * summgene: Summarize a single genotype
  */
 
-static summgene (f, gene)
-register FILE *f;
-register genotype *gene;
+static void
+summgene (FILE *f, genotype *gene)
 {
   fprintf (f, "%3d age %2d, created %4d, ",
            gene->id, TRIALS(gene), gene->creation);
@@ -472,9 +478,8 @@ register genotype *gene;
  * Birth: Summarize Record the birth of a genotype.
  */
 
-static birth (f, gene)
-register FILE *f;
-register genotype *gene;
+static void
+birth (FILE *f, genotype *gene)
 {
   if (!glog) return;
 
@@ -494,11 +499,10 @@ register genotype *gene;
  * printdna: Print the genotype of a gene
  */
 
-static printdna (f, gene)
-FILE *f;
-register genotype *gene;
+static void
+printdna (FILE *f, genotype *gene)
 {
-  register int i;
+  int i;
 
   fprintf (f, "(");
 
@@ -515,10 +519,10 @@ register genotype *gene;
  * cross: Cross two genotypes producing a new genotype
  */
 
-static cross (father, mother, new)
-register int father, mother, new;
+static void
+cross (int father, int mother, int new)
 {
-  register int cpoint, i;
+  int cpoint, i;
 
   /* Set the new genotypes info */
   genes[new]->id = ++lastid;
@@ -555,10 +559,10 @@ register int father, mother, new;
  * mutate: mutate a genes producing a new gene
  */
 
-static mutate (father, new)
-register int father, new;
+static void
+mutate (int father, int new)
 {
-  register int i;
+  int i;
 
   /* Set the new genotypes info */
   genes[new]->id = ++lastid;
@@ -593,10 +597,10 @@ register int father, new;
  * shift: shift a gene producing a new gene
  */
 
-static shift (father, new)
-register int father, new;
+static void
+shift (int father, int new)
 {
-  register int i, offset;
+  int i, offset;
 
   /* Set the new genotypes info */
   genes[new]->id = ++lastid;
@@ -628,10 +632,10 @@ register int father, new;
  * randompool: Initialize the pool to a random starting point
  */
 
-static randompool (m)
-register int m;
+static void
+randompool (int m)
 {
-  register int i, g;
+  int i, g;
 
   for (g=0; g<m; g++) {
     if (g >= length) {
@@ -654,11 +658,11 @@ register int m;
  * selectgene: Select a random gene, weighted by mean score.
  */
 
-static selectgene (e1, e2)
-register int e1, e2;
+static int
+selectgene (int e1, int e2)
 {
-  register int total=0;
-  register int g;
+  int total=0;
+  int g;
 
   /* Find the total worth */
   for (g=0; g<length; g++) {
@@ -690,10 +694,10 @@ register int e1, e2;
  * unique: Return false if gene is an exact copy of another gene.
  */
 
-static unique (new)
-register int new;
+static int
+unique (int new)
 {
-  register int g, i, delta, sumsquares;
+  int g, i, delta, sumsquares;
 
   for (g=0; g<length; g++) {
     if (g != new) {
@@ -717,9 +721,10 @@ register int new;
  * greater for older genotypes.
  */
 
-static untested ()
+static int
+untested (void)
 {
-  register int g, y= -1, trials=1e9, newtrials, count=length;
+  int g, y= -1, trials=1e9, newtrials, count=length;
 
   for (g = rogo_randint (length); count-- > 0; g = (g+1) % length) {
     if (TRIALS (genes[g]) >= trials) continue;
@@ -737,9 +742,10 @@ static untested ()
  * youngest: Return the index of the youngest genotype
  */
 
-static youngest ()
+static int
+youngest (void)
 {
-  register int g, y=0, trials=1e9, newtrials, count=length;
+  int g, y=0, trials=1e9, newtrials, count=length;
 
   for (g = rogo_randint (length); count-- > 0; g = (g+1) % length) {
     newtrials = TRIALS (genes[g]);
@@ -754,10 +760,10 @@ static youngest ()
  * makeunique: Mutate a genotype until it is unique
  */
 
-static makeunique (new)
-register int new;
+static void
+makeunique (int new)
 {
-  register int i;
+  int i;
 
   while (!unique (new)) {
     i=rogo_randint (MAXKNOB);
@@ -770,10 +776,10 @@ register int new;
  * triangle: Return a non-zero triangularly distributed number from -n to n.
  */
 
-static triangle (n)
-register int n;
+static int
+triangle (int n)
 {
-  register int val;
+  int val;
 
   do {
     val = rogo_randint (n) - rogo_randint (n);
@@ -788,10 +794,10 @@ register int n;
  * only consider genotypes dominated by other genotypes.
  */
 
-static badgene (e1, e2)
-register int e1, e2;
+static int
+badgene (int e1, int e2)
 {
-  register int g, worst, trials;
+  int g, worst, trials;
   double worstval, bestval, avg, dev, value;
 
   worst = -1; worstval = 1.0e9;

--- a/rogomatic/src/ltm.c
+++ b/rogomatic/src/ltm.c
@@ -31,19 +31,26 @@
 # include <curses.h>
 # include <math.h>
 # include <string.h>
+# include <time.h>
+
 # include "types.h"
 # include "globals.h"
 # include "install.h"
 
+/* static declarations */
 static int nosave = 0;		/* True ==> dont write ltm back out */
 static char ltmnam[100];	/* Long term memory file name */
+
+static void readltm (void);
+static void parsemonster (char *monster);
+static void clearltm (ltmrec *ltmarr);
 
 /*
  * mapcharacter: Read a character help message
  */
 
-mapcharacter (ch, str)
-char ch, *str;
+void
+mapcharacter (char ch, char *str)
 {
   dwait (D_CONTROL, "mapcharacter called: '%c' ==> '%s'", ch, str);
 
@@ -65,10 +72,10 @@ char ch, *str;
  * history array.  Create an entry if none exists.
  */
 
-int addmonhist (monster)
-char *monster;
+int
+addmonhist (char *monster)
 {
-  register int m;
+  int m;
 
   /* Search for the monsters entry in the table */
   for (m=0; m<nextmon; m++)
@@ -87,10 +94,10 @@ char *monster;
  * history array.  Return -1 if the monster is not in the table.
  */
 
-int findmonster (monster)
-char *monster;
+int
+findmonster (char *monster)
 {
-  register int m;
+  int m;
 
   /* Search for the monsters entry in the table */
   for (m=0; m<nextmon; m++)
@@ -106,11 +113,11 @@ char *monster;
  * access to the output file.
  */
 
-saveltm (score)
-int score;
+void
+saveltm (int score)
 {
-  register int m;
-  register FILE *ltmfil;
+  int m;
+  FILE *ltmfil;
 
   if (nextmon < 1 || nosave) return;
 
@@ -155,7 +162,8 @@ int score;
  * restoreltm: Read the long term memory file.
  */
 
-restoreltm ()
+void
+restoreltm (void)
 {
   sprintf (ltmnam, "%s/ltm%d", getRgmDir (), version);
   dwait (D_CONTROL, "Restoreltm called, reading file '%s'", ltmnam);
@@ -193,10 +201,11 @@ restoreltm ()
  * into storage.  Be careful about serializing access to the file.
  */
 
-readltm ()
+static void
+readltm (void)
 {
   char buf[BUFSIZ];
-  register FILE *ltmfil;
+  FILE *ltmfil;
 
   if ((ltmfil = fopen (ltmnam, "r")) == NULL) {
     nosave = 1;
@@ -222,12 +231,11 @@ readltm ()
  * parsemonster: parse one line from the ltm file.
  */
 
-parsemonster (monster)
-char *monster;
+static void
+parsemonster (char *monster)
 {
-  register char *attrs;
-  char *index();
-  register int m;
+  char *attrs;
+  int m;
 
   /* Separate the monster name from the attributes */
   if ((attrs = index (monster, '|')) == NULL) return;
@@ -250,10 +258,10 @@ char *monster;
  * clearltm: Clear a whole long term memory array.
  */
 
-clearltm (ltmarr)
-register ltmrec *ltmarr;
+static void
+clearltm (ltmrec *ltmarr)
 {
-  register int i;
+  int i;
 
   for (i=0; i<MAXMON; i++) {
     ltmarr[i].m_name[0] = '\0';
@@ -270,9 +278,10 @@ register ltmrec *ltmarr;
  * dumpmonstertable: Format and print the monster table on the screen
  */
 
-dumpmonstertable ()
+void
+dumpmonstertable (void)
 {
-  register int m;
+  int m;
   char monc;
 
   clear (); mvprintw (0,0,"Monster table:");
@@ -300,9 +309,10 @@ dumpmonstertable ()
  * analyzeltm: Set the monatt array based on current long term memory.
  */
 
-analyzeltm ()
+void
+analyzeltm (void)
 {
-  register int m, i;
+  int m, i;
   double avg_dam = 0.6*Level+3, max_dam = 7.0+Level, avg_arr = 4.0;
   double phit, mean_dam, stdev_dam, three_dev;
 

--- a/rogomatic/src/main.c
+++ b/rogomatic/src/main.c
@@ -102,9 +102,10 @@
 # include <stdlib.h>
 # include <sys/types.h>
 # include <unistd.h>
+
 # include "types.h"
-# include "termtokens.h"
 # include "install.h"
+# include "termtokens.h"
 
 
 /* FIXME: get rid of this prototype in the correct way */
@@ -121,7 +122,7 @@ FILE  *trogue=NULL;		/* Pipe to Rogue process */
 /* Characters */
 char  logfilename[100];		/* Name of log file */
 char  afterid = '\0';           /* Letter of obj after identify */
-char  genelock[100];		/* Gene pool lock file */
+static char  genelock[100];	/* Gene pool lock file */
 char  genelog[100];		/* Genetic learning log file */
 char  genepool[100];		/* Gene pool */
 char  *genocide;		/* List of monsters to be genocided */
@@ -131,7 +132,7 @@ char  lastname[NAMSIZ];		/* Name of last potion/scroll/wand */
 char  nextid = '\0';            /* Next object to identify */
 char  screen[24][80];		/* Map of current Rogue screen */
 char  sumline[128];		/* Termination message for Rogomatic */
-char  ourkiller[NAMSIZ];		/* How we died */
+char  ourkiller[NAMSIZ];	/* How we died */
 char  versionstr[32];		/* Version of Rogue being used */
 char  *parmstr;			/* Pointer to process arguments */
 char  pending_call_letter = ' ';	/* If non-blank we have a call it to do */
@@ -168,9 +169,9 @@ int   darkturns = 0;		/* Distance to monster being arched */
 int   debugging = D_NORMAL;	/* Debugging options in effect */
 int   didreadmap = 0;		/* Last level we read a map on */
 int   doorlist[40];		/* List of doors on this level */
-int   doublehasted = 0; 	/* True if double hasted (Rogue 3.6) */
+int   doublehasted = 0;		/* True if double hasted (Rogue 3.6) */
 int   droppedscare = 0;		/* True if we dropped 'scare' on this level */
-int   diddrop = 0;	/* True if we dropped anything on this spot */
+int   diddrop = 0;		/* True if we dropped anything on this spot */
 int   emacs = 0;		/* True ==> format output for Emacs */
 int   exploredlevel = 0;	/* We completely explored this level */
 int   floating = 0;		/* True if we are levitating */
@@ -244,11 +245,10 @@ int   zonemap[9][9];		/* Map of zones connections */
 
 /* Functions */
 void (*istat)(int);
-void onintr (int sig);
 char getroguetoken (), *getname();
 
 /* Stuff list, list of objects on this level */
-stuffrec slist[MAXSTUFF]; 	int slistlen=0;
+stuffrec slist[MAXSTUFF];	int slistlen=0;
 
 /* Monster list, list of monsters on this level */
 monrec mlist[MAXMONST];		int mlistlen=0;
@@ -274,7 +274,7 @@ int k_exper =	50;	/* Level*10 on which to experiment with items */
 int k_run =	50;	/* Propensity for retreating */
 int k_wake =	50;	/* Propensity for waking things up */
 int k_food =	50;	/* Propensity for hoarding food (affects rings) */
-int knob[MAXKNOB] = {50, 50, 50, 50, 50, 50, 50, 50};
+static int knob[MAXKNOB] = {50, 50, 50, 50, 50, 50, 50, 50};	/* Knobs */
 char *knob_name[MAXKNOB] = {
   "trap searching:   ",
   "door searching:   ",
@@ -339,17 +339,21 @@ char roguename[100];
 /* Used by onintr() to restart Rgm at top of command loop */
 jmp_buf  commandtop;
 
+/* static declarations */
+static void onintr (int sig);
+static void startlesson (void);
+static void endlesson (void);
+
 /*
  * Main program
  */
 
-main (argc, argv)
-int   argc;
-char *argv[];
+int
+main (int argc, char *argv[])
 {
-  char  ch, *s, *getenv(), *statusline(), msg[128];
+  char  ch, *s, msg[128];
   int startingup = 1;
-  register int  i;
+  int  i;
 
   debuglog_open ("debuglog.player");
 
@@ -366,7 +370,7 @@ char *argv[];
   for (i = 80 * 24; i--; ) screen[0][i] = ' ';
 
   /*
-   * Get the process id of this player program if the 
+   * Get the process id of this player program if the
    * environment variable is set which requests this be
    * done.  Then create the file name with the PID so
    * that the debugging scripts can find it and use the
@@ -432,7 +436,7 @@ char *argv[];
   arglen = 0;
 
   for (i=0; i<argc; i++) {
-    register int len = strlen (argv[i]);
+    int len = strlen (argv[i]);
     arglen += len + 1;
 
     while (len >= 0) argv[i][len--] = ' ';
@@ -776,7 +780,7 @@ char *argv[];
     char lognam[128];
 
     /* Make up a new log file name */
-    sprintf (lognam, "%0.4s.%d.%d", ourkiller, MaxLevel, ourscore);
+    sprintf (lognam, "%.4s.%d.%d", ourkiller, MaxLevel, ourscore);
 
     /* Close the open file */
     toggleecho ();
@@ -802,7 +806,8 @@ char *argv[];
  * and reset some goal variables.
  */
 
-void onintr (int sig)
+static void
+onintr (int sig)
 {
   sendnow ("n\033");            /* Tell Rogue we don't want to quit */
   refresh ();                   /* Clear terminal output */
@@ -819,7 +824,8 @@ void onintr (int sig)
  * test this game, and set the parameters (or "knobs") accordingly.
  */
 
-startlesson ()
+static void
+startlesson (void)
 {
   int tmpseed = 0;
 
@@ -873,7 +879,8 @@ startlesson ()
  * evaluate the performance of this genotype and save in genepool.
  */
 
-endlesson ()
+static void
+endlesson (void)
 {
   if (geneid > 0 &&
       (stlmatch (termination, "perditus") ||

--- a/rogomatic/src/mess.c
+++ b/rogomatic/src/mess.c
@@ -30,13 +30,15 @@
 # include <curses.h>
 # include <ctype.h>
 # include <string.h>
+# include <stdlib.h>
+
 # include "types.h"
 # include "globals.h"
 
-extern int clearsendqueue ();
-
 /* Matching macros */
 # define MATCH(p) smatch(mess,p,result)
+
+/* static declarations */
 
 /* Local data recording statistics */
 static int monkilled[] = {
@@ -46,10 +48,10 @@ static int monkilled[] = {
 static int totalkilled=0, timeshit=0, timesmissed=0, hits=0, misses=0;
 static int sumgold=0, sumsqgold=0, numgold=0;
 
-static mhit=0, mmiss=0, mtarget= NONE;
+static int mhit=0, mmiss=0, mtarget= NONE;
 
 /* Other local data */
-int identifying = 0;		/* Next message is from identify scroll */
+static int identifying = 0;	/* Next message is from identify scroll */
 static int justreadid = 0;	/* True if just read identify scroll */
 static int gushed = 0;		/* True ==> water on the head msg recently */
 static int echoit;		/* True ==> echo this message to the user */
@@ -57,6 +59,20 @@ static int echoit;		/* True ==> echo this message to the user */
 /* Results from star matcher */
 static char res1[NAMSIZ], res2[NAMSIZ], res3[NAMSIZ], res4[NAMSIZ], res5[NAMSIZ];
 static char *result[] = { res1, res2, res3, res4, res5 };
+
+static void parsemsg (char *mess, char *mend);
+static int smatch (char *dat, char *pat, char **res);
+static void readident (char *name);
+static void rampage (void);
+static void curseditem (void);
+static void washit (char *monster);
+static void wasmissed (char *monster);
+static void didhit (void);
+static void didmiss (void);
+static void mshit (char *monster);
+static void msmiss (char *monster);
+static void countgold (char *amount);
+static int getmonhist (char *monster, int hitormiss);
 
 /*
  * terpmes: called when a message from Rogue is on the top line,
@@ -70,10 +86,11 @@ static char *result[] = { res1, res2, res3, res4, res5 };
  * multiple messages.
  */
 
-terpmes ()
+void
+terpmes (void)
 {
   char mess[128]; char topline[128];
-  register char *m, *mend, *s, *t;
+  char *m, *mend, *s, *t;
 
   s=&screen[0][0];
   memset (topline, '\0', 128);
@@ -153,8 +170,8 @@ terpmes ()
  * or call functions.
  */
 
-parsemsg (mess, mend)
-register char *mess, *mend;
+static void
+parsemsg (char *mess, char *mend)
 {
   int unknown = 0;
 
@@ -456,7 +473,7 @@ register char *mess, *mend;
         else if (MATCH("this potion tastes pretty*")) infer ("thirst quenching", potion);
         else if (MATCH("this potion tastes like * juice*"))
           { infer ("see invisible", potion); if (version == RV36A) sendnow ("%c", ESC); }
-        else if (MATCH("this scroll seems to be blank*")) infer ("blank paper");
+        else if (MATCH("this scroll seems to be blank*")) infer ("blank paper", Scroll);
         else if (MATCH("the * bounces*")) ;
         else if (MATCH("the * vanishes as it hits the ground*"))
           { darkturns = 0; darkdir = NONE; targetmonster = 0; echoit=0; }
@@ -705,37 +722,37 @@ register char *mess, *mend;
  * characters matched by the 'i'th *.
  */
 
-smatch (dat, pat, res)
-register char *dat, *pat, **res;
+static int
+smatch (char *dat, char *pat, char **res)
 {
-  register char *star = 0, *starend, *resp;
+  char *star = 0, *starend, *resp;
   int nres = 0;
 
   while (1) {
     if (*pat == '*') {
-      star = ++pat; 			     /* Pattern after * */
-      starend = dat; 			     /* Data after * match */
-      resp = res[nres++]; 		     /* Result string */
-      *resp = '\0'; 			     /* Initially null */
+      star = ++pat;			     /* Pattern after * */
+      starend = dat;			     /* Data after * match */
+      resp = res[nres++];		     /* Result string */
+      *resp = '\0';			     /* Initially null */
     }
-    else if (*dat == *pat) {	     /* Characters match */
-      if (*pat == '\0') 		     /* Pattern matches */
+    else if (*dat == *pat) {		     /* Characters match */
+      if (*pat == '\0')			     /* Pattern matches */
         return (1);
 
-      pat++; 				     /* Try next position */
+      pat++;				     /* Try next position */
       dat++;
     }
     else {
-      if (*dat == '\0') 		     /* Pattern fails - no more */
-        return (0); 			     /* data */
+      if (*dat == '\0')			     /* Pattern fails - no more */
+        return (0);			     /* data */
 
-      if (star == 0) 			     /* Pattern fails - no * to */
-        return (0); 			     /* adjust */
+      if (star == 0)			     /* Pattern fails - no * to */
+        return (0);			     /* adjust */
 
-      pat = star; 			     /* Restart pattern after * */
-      *resp++ = *starend; 		     /* Copy character to result */
-      *resp = '\0'; 			     /* null terminate */
-      dat = ++starend; 			     /* Rescan after copied char */
+      pat = star;			     /* Restart pattern after * */
+      *resp++ = *starend;		     /* Copy character to result */
+      *resp = '\0';			     /* null terminate */
+      dat = ++starend;			     /* Rescan after copied char */
     }
   }
 }
@@ -744,8 +761,8 @@ register char *dat, *pat, **res;
  * readident: we have read an identify scroll.
  */
 
-readident (name)
-char *name;
+static void
+readident (char *name)
 {
   int obj; char id = '*';	/* Default is "* for list" */
   stuff item_type = none;
@@ -845,12 +862,13 @@ char *name;
  * rampage: read a scroll of genocide.
  */
 
-rampage ()
+static void
+rampage (void)
 {
   char monc;
 
   /* Check the next monster in the list, we may not fear him */
-  while (monc = *genocide) {
+  while ((monc = *genocide)) {
     /* Do not waste genocide on stalkers if we have the right ring */
     if ((streq (monname (monc), "invisible stalker") ||
          streq (monname (monc), "phantom")) &&
@@ -889,7 +907,8 @@ rampage ()
  * Good rings we have identified, so don't bother marking rings.
  */
 
-curseditem ()
+static void
+curseditem (void)
 {
   usesynch = 0;    /* Force a reset inventory */
 
@@ -921,16 +940,15 @@ curseditem ()
  * base, and then zap that name into all of the same objects
  */
 
-infer (objname, item_type)
-char *objname;
-stuff item_type;
+void
+infer (char *objname, stuff item_type)
 {
-  register int i;
+  int i;
 
   if (*lastname && *objname && !stlmatch (objname, lastname)) {
     infername (lastname, objname, item_type);
     for (i=0; i<MAXINV; i++) {
-      if ((inven[i].count > 0) && 
+      if ((inven[i].count > 0) &&
            streq (inven[i].str, lastname) && inven[i].type == item_type) {
         memset (inven[i].str, '\0', NAMSIZ);
         strncpy (inven[i].str, objname, NAMSIZ-1);
@@ -944,10 +962,10 @@ stuff item_type;
  * Killed: called whenever we defeat a monster.
  */
 
-killed (monster)
-register char *monster;
+void
+killed (char *monster)
 {
-  register int m = 0, mh = 0;
+  int m = 0, mh = 0;
 
   /* Find out what we really killed */
   if (!cosmic && !blinded && targetmonster>0 && streq (monster, "it"))
@@ -1001,10 +1019,10 @@ register char *monster;
  * washit: Record being hit by a monster.
  */
 
-washit (monster)
-char *monster;
+static void
+washit (char *monster)
 {
-  register int mh = 0, m = 0;
+  int mh = 0, m = 0;
 
   /* Find out what really hit us */
   if ((mh = getmonhist (monster, 1)) != NONE)
@@ -1030,10 +1048,10 @@ char *monster;
  * wasmissed: Record being missed by a monster.
  */
 
-wasmissed (monster)
-char *monster;
+static void
+wasmissed (char *monster)
 {
-  register int mh = 0, m = 0;
+  int mh = 0, m = 0;
 
   /* Find out what really missed us */
   if ((mh = getmonhist (monster, 1)) != NONE)
@@ -1056,9 +1074,10 @@ char *monster;
  * didhit: Record hitting a monster.
  */
 
-didhit ()
+static void
+didhit (void)
 {
-  register int m = 0;
+  int m = 0;
 
   /* Record our hit */
   if (!cosmic) m = lastmonster;
@@ -1074,9 +1093,10 @@ didhit ()
  * didmiss: Record missing a monster.
  */
 
-didmiss ()
+static void
+didmiss (void)
 {
-  register int m = 0;
+  int m = 0;
 
   /* Record our miss */
   if (!cosmic) m = lastmonster;
@@ -1092,10 +1112,10 @@ didmiss ()
  * mshit: Record hitting a monster with a missile.
  */
 
-mshit (monster)
-char *monster;
+static void
+mshit (char *monster)
 {
-  register int mh;
+  int mh;
 
   /* Arching in a dark room? */
   if (!cosmic && !blinded && targetmonster > 0 && streq (monster, "it"))
@@ -1116,10 +1136,10 @@ char *monster;
  * msmiss: Record missing a monster with a missile.
  */
 
-msmiss (monster)
-char *monster;
+static void
+msmiss (char *monster)
 {
-  register int mh;
+  int mh;
 
   /* Arching in a dark room? */
   if (!cosmic && !blinded && targetmonster > 0 && streq (monster, "it"))
@@ -1142,8 +1162,8 @@ char *monster;
  *            statistics about the amount of gold picked up.
  */
 
-countgold (amount)
-register char *amount;
+static void
+countgold (char *amount)
 {
   int pot;
 
@@ -1155,12 +1175,11 @@ register char *amount;
  * Summary: print a summary of the game.
  */
 
-summary (f, sep)
-FILE *f;
-char sep;
+void
+summary (FILE *f, char sep)
 {
-  register int m;
-  char s[1024], *monname ();
+  int m;
+  char s[1024];
 
   sprintf (s, "Monsters killed:%c%c", sep, sep);
 
@@ -1190,7 +1209,8 @@ char sep;
  * versiondep: Set version dependent variables.
  */
 
-versiondep ()
+void
+versiondep (void)
 {
   if (version >= RV53A)		genocide = "DMJGU";
   else if (version >= RV52A)	genocide = "UDVPX";
@@ -1205,9 +1225,8 @@ versiondep ()
  * when we are being stalked by an invisible monster.
  */
 
-getmonhist (monster, hitormiss)
-char *monster;
-int hitormiss;
+static int
+getmonhist (char *monster, int hitormiss)
 {
   if (cosmic || blinded)
     { return (findmonster ("it")); }

--- a/rogomatic/src/monsters.c
+++ b/rogomatic/src/monsters.c
@@ -30,6 +30,8 @@
 # include <stdio.h>
 # include <ctype.h>
 # include <curses.h>
+# include <string.h>
+
 # include "types.h"
 # include "globals.h"
 
@@ -40,8 +42,8 @@
  * monname: Return a monster name given letter '@ABC..Z'
  */
 
-char *monname (m)
-char m;
+char *
+monname (char m)
 {
   return (monhist[monindex[m-'A'+1]].m_name);
 }
@@ -51,9 +53,8 @@ char m;
  * list which are in the same square.
  */
 
-addmonster (ch, r, c, quiescence)
-char  ch;
-int   r, c, quiescence;
+void
+addmonster (char ch, int r, int c, int quiescence)
 {
   char *monster = monname (ch);
 
@@ -82,8 +83,8 @@ int   r, c, quiescence;
  * deletemonster: remove a monster from the list at location (row, col).
  */
 
-deletemonster (r, c)
-int   r, c;
+void
+deletemonster (int r, int c)
 {
   int   i;
 
@@ -99,7 +100,8 @@ int   r, c;
  * dumpmonsters: (debugging) dump the list of monsters on this level.
  */
 
-dumpmonster ()
+void
+dumpmonster (void)
 {
   int   i;
   at (1, 0);
@@ -123,9 +125,10 @@ dumpmonster ()
  * it sat still for a turn and must be asleep.
  */
 
-sleepmonster ()
+void
+sleepmonster (void)
 {
-  register int m;
+  int m;
 
   for (m = 0; m < mlistlen; ++m) {
     if (mlist[m].q == 0 && ! ADJACENT (m)) {
@@ -141,9 +144,10 @@ sleepmonster ()
  * holdmonsters: Mark all close monsters as being held.
  */
 
-holdmonsters ()
+void
+holdmonsters (void)
 {
-  register int m;
+  int m;
 
   for (m = 0; m < mlistlen; ++m) {
     if (mlist[m].q == 0 &&
@@ -166,10 +170,10 @@ holdmonsters ()
  * dir = -m  means wake up all adjacent monsters of type m.
  */
 
-wakemonster (dir)
-int dir;
+void
+wakemonster (int dir)
 {
-  register int m;
+  int m;
 
   for (m = 0; m < mlistlen; ++m) {
     if (mlist[m].q != AWAKE &&
@@ -190,10 +194,10 @@ int dir;
  * seemonster: Return true if a particular monster is on the monster list.
  */
 
-seemonster (monster)
-char *monster;
+int
+seemonster (char *monster)
 {
-  register int m;
+  int m;
 
   for (m = 0; m < mlistlen; ++m)
     if (streq (monname (mlist[m].chr), monster))
@@ -207,10 +211,10 @@ char *monster;
  * monster on the monster list.		DR UTexas 26 Jan 84
  */
 
-seeawakemonster (monster)
-char *monster;
+int
+seeawakemonster (char *monster)
 {
-  register int m;
+  int m;
 
   for (m = 0; m < mlistlen; ++m)
     if (streq (monname (mlist[m].chr), monster) && mlist[m].q == AWAKE)
@@ -225,8 +229,8 @@ char *monster;
  *             is used for unknown monsters (e.g. "it").
  */
 
-monsternum (monster)
-char *monster;
+int
+monsternum (char *monster)
 {
   int m, mh;
 
@@ -242,10 +246,11 @@ char *monster;
  * each monster.
  */
 
-newmonsterlevel ()
+void
+newmonsterlevel (void)
 {
-  register int m;
-  register char *monster;
+  int m;
+  char *monster;
 
   for (m=0; m<mlistlen; m++) {
     monster = monname (mlist[m].chr);
@@ -264,8 +269,8 @@ newmonsterlevel ()
  * isholder: Return true if the monster can hold us.
  */
 
-isholder (monster)
-register char *monster;
+int
+isholder (char *monster)
 {
   return (streq (monster, "venus flytrap") || streq (monster, "violet fungi"));
 }

--- a/rogomatic/src/pack.c
+++ b/rogomatic/src/pack.c
@@ -29,8 +29,12 @@
 
 # include <curses.h>
 # include <string.h>
+# include <stdlib.h>
+
 # include "types.h"
 # include "globals.h"
+
+/* static declarations */
 
 static char *stuffmess [] = {
   "strange", "food", "potion", "scroll",
@@ -39,15 +43,20 @@ static char *stuffmess [] = {
   "none"
 };
 
+static void clearpack (int pos);
+static void rollpackup (int pos);
+static void rollpackdown (int pos);
+static void countpack (void);
+
 /*
  * itemstr: print the inventory message for a single item.
  */
 
-char *itemstr (i)
-register int i;
+char *
+itemstr (int i)
 {
   static char ispace[128];
-  register char *item = ispace;
+  char *item = ispace;
 
   memset (ispace, '\0', 128);
 
@@ -88,10 +97,10 @@ register int i;
  * dumpinv: print the inventory. calls itemstr.
  */
 
-dumpinv (f)
-register FILE *f;
+void
+dumpinv (FILE *f)
 {
-  register int i;
+  int i;
 
   if (f == NULL)
     at (1,0);
@@ -111,8 +120,8 @@ register FILE *f;
  * removeinv: remove an item from the inventory.
  */
 
-removeinv (pos)
-int pos;
+void
+removeinv (int pos)
 {
   if (--(inven[pos].count) == 0) {
     clearpack  (pos);		/* Assure nothing at that spot  DR UT */
@@ -133,8 +142,8 @@ int pos;
  * things can be dropped all at once.
  */
 
-deleteinv (pos)
-int pos;
+void
+deleteinv (int pos)
 {
 
   if (--(inven[pos].count) == 0 || inven[pos].type == missile) {
@@ -154,8 +163,8 @@ int pos;
  * clearpack: zero out slot in pack.  DR UTexas 01/05/84
  */
 
-clearpack (pos)
-int pos;
+static void
+clearpack (int pos)
 {
   if (pos >= MAXINV) return;
 
@@ -180,11 +189,11 @@ int pos;
  * the pack.
  */
 
-rollpackup (pos)
-register int pos;
+static void
+rollpackup (int pos)
 {
-  register char *savebuf;
-  register int i;
+  char *savebuf;
+  int i;
 
   if (version >= RV53A) return;
 
@@ -215,11 +224,11 @@ register int pos;
  * objects behind that position.
  */
 
-rollpackdown (pos)
-register int pos;
+static void
+rollpackdown (int pos)
 {
-  register char *savebuf;
-  register int i;
+  char *savebuf;
+  int i;
 
   if (version >= RV53A) {
     return;
@@ -251,7 +260,8 @@ register int pos;
  * doresetinv.
  */
 
-resetinv()
+void
+resetinv(void)
 {
   if (!replaying) {
     command (T_OTHER, "i");
@@ -270,7 +280,8 @@ resetinv()
  * doresetinv: reset the inventory.  DR UTexas 01/05/84
  */
 
-doresetinv ()
+void
+doresetinv (void)
 {
   int i;
   static char space[MAXINV][80];
@@ -295,10 +306,10 @@ doresetinv ()
 
 # define xtr(w,b,e,k) {what=(w);xbeg=mess+(b);xend=mend-(e);xknow|=(k);}
 
-inventory (msgstart, msgend)
-char *msgstart, *msgend;
+int
+inventory (char *msgstart, char *msgend)
 {
-  register char *p, *q, *mess = msgstart, *mend = msgend;
+  char *p, *q, *mess = msgstart, *mend = msgend;
   char objname[100];
   char dbname[NAMSIZ];
   char codename[NAMSIZ];
@@ -482,7 +493,7 @@ char *msgstart, *msgend;
   dwait (D_PACK, "inv    ht %d dm %d ch %d kn %d",
          plushit, plusdam, charges, xknow);
 
-  /* make sure all unknown potion, Scroll, wand, rings 
+  /* make sure all unknown potion, Scroll, wand, rings
      are in dbase */
   if (!xknow && (what == potion || what == Scroll || what == wand || what == ring)) {
     addobj (objname, ipos, what);
@@ -636,9 +647,10 @@ char *msgstart, *msgend;
  * countpack: Count objects, missiles, and food in the pack.
  */
 
-countpack ()
+static void
+countpack (void)
 {
-  register int i, cnt;
+  int i, cnt;
 
   for (objcount=0, larder=0, ammo=0, i=0; i<invcount; i++) {
     if (! (cnt = inven[i].count))	; /* No object here */

--- a/rogomatic/src/rand.c
+++ b/rogomatic/src/rand.c
@@ -21,6 +21,8 @@
  * along with Rog-O-Matic.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+# include <time.h>
+
 /*
  * rand.c:
  *
@@ -67,10 +69,10 @@
 # define AUXLEN 97
 static int seed1=872978, seed2=518652, seed3=226543, auxtab[AUXLEN];
 
-rogo_srand (seed)
-int seed;
+void
+rogo_srand (int seed)
 {
-  register int i;
+  int i;
 
   if (seed == 0) seed = time (0);
 
@@ -83,9 +85,10 @@ int seed;
     auxtab[i] = X;
 }
 
-int rogo_rand ()
+int
+rogo_rand (void)
 {
-  register int j, result;
+  int j, result;
 
   j = AUXLEN * Y / MOD1;	/* j random from 0..AUXLEN-1 */
   result = auxtab[j];
@@ -93,10 +96,10 @@ int rogo_rand ()
   return (result);
 }
 
-rogo_randint (max)
-register int max;
+int
+rogo_randint (int max)
 {
-  register int j, result;
+  int j, result;
 
   j = AUXLEN * Y / MOD1;	/* j random from 0..AUXLEN-1 */
   result = auxtab[j];

--- a/rogomatic/src/replay.c
+++ b/rogomatic/src/replay.c
@@ -31,6 +31,7 @@
 # include <curses.h>
 # include <ctype.h>
 # include <string.h>
+
 # include "types.h"
 # include "globals.h"
 
@@ -43,7 +44,13 @@ struct levstruct {
   long pos;
   int  level, gold, hp, hpmax, str, strmax, ac, explev, exp;
 } levpos[MAXNUMLEV];
-int numlev = 0;
+
+/* static declarations */
+static int numlev = 0;
+
+static int findlevel (FILE *f, struct levstruct *lvpos, int *nmlev, int maxnum);
+static void fillstruct (FILE *f, struct levstruct *lev);
+static int findmatch (FILE *f, char *s);
 
 /*
  * positionreplay: Called when user has typed the 'R' command, it fills
@@ -51,7 +58,8 @@ int numlev = 0;
  * the log file to the level requested by the user.
  */
 
-positionreplay ()
+void
+positionreplay (void)
 {
   int curlev;
   long curpos;
@@ -111,7 +119,7 @@ positionreplay ()
   }
 
   clearscreen ();	/* Clear the screen */
-  Level = -1; 		/* Force a newlevel() call */
+  Level = -1;		/* Force a newlevel() call */
 }
 
 /*
@@ -119,10 +127,8 @@ positionreplay ()
  *             Rog-O-Matic log file.
  */
 
-findlevel (f, lvpos, nmlev, maxnum)
-FILE *f;
-struct levstruct *lvpos;
-int *nmlev, maxnum;
+static int
+findlevel (FILE *f, struct levstruct *lvpos, int *nmlev, int maxnum)
 {
   char ch;
   int l=0;
@@ -160,9 +166,8 @@ int *nmlev, maxnum;
  * fields of a levstruct.
  */
 
-fillstruct (f, lev)
-FILE *f;
-struct levstruct *lev;
+static void
+fillstruct (FILE *f, struct levstruct *lev)
 {
   lev->level  = 0;
   lev->gold   = 0;
@@ -209,9 +214,8 @@ struct levstruct *lev;
  * Restriction: 's' must not contain prefix of itself as a substring.
  */
 
-int findmatch (f, s)
-FILE *f;
-char *s;
+static int
+findmatch (FILE *f, char *s)
 {
   char *m = s, ch;
 

--- a/rogomatic/src/rgmplot.c
+++ b/rogomatic/src/rgmplot.c
@@ -31,21 +31,31 @@
 # include <stdio.h>
 # include <stdlib.h>
 # include <string.h>
+
+# include "types.h"
+
 # define WIDTH 50
 # define AVLEN 7
 # define SCALE(n) (((n)+100)/200)
 # define isdigit(c) ((c) >= '0' && (c) <= '9')
 
-char *month[] = {
+int cheat = 0;
+
+/* static declarations */
+
+static char *month[] = {
   "Jan", "Feb", "Mar", "Apr", "May", "Jun",
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
 };
 
-int doavg = 0, cheat = 0, min = -1;
+static int doavg = 0;
+static int minscore = -1;
 
-main (argc, argv)
-int argc;
-char *argv[];
+static int getlin (char *s);
+static int getscore (int *mm, int *dd, int *yy, char *player, int *score, char *cheated);
+
+int
+main (int argc, char *argv[])
 {
   int mm, dd, yy, score = 0, lastday = -1, lastmon = -1, lastyy = -1, h;
   int sumscores = 0, numscores = 0, i;
@@ -67,13 +77,13 @@ char *argv[];
       }
     }
 
-  if (argc > 0) min = atoi (argv[0]);
+  if (argc > 0) minscore = atoi (argv[0]);
 
   /*  Print out the header */
   printf ("\t\t   Scatter Plot of Rog-O-Matic Scores versus time\n\n");
 
-  if (min > 0)
-    printf ("\t\t              Scores greater than %d\n\n", min);
+  if (minscore > 0)
+    printf ("\t\t              Scores greater than %d\n\n", minscore);
 
   printf ("\t\t0      2000      4000      6000      8000     10000\n");
   printf ("\t\t|----+----|----+----|----+----|----+----|----+----|\n");
@@ -148,8 +158,8 @@ char *argv[];
 }
 
 
-getlin (s)
-char *s;
+static int
+getlin (char *s)
 {
   int ch, i;
   static int endfile = 0;
@@ -170,9 +180,8 @@ char *s;
   return (i);
 }
 
-getscore (mm, dd, yy, player, score, cheated)
-int *mm, *dd, *yy, *score;
-char *player, *cheated;
+static int
+getscore (int *mm, int *dd, int *yy, char *player, int *score, char *cheated)
 {
   char line[128], reason[32];
 
@@ -180,7 +189,7 @@ char *player, *cheated;
     sscanf (line, "%d %d, %d %10s%d%c%17s",
             mm, dd, yy, player, score, cheated, reason);
 
-    if ((*score >= min || *score < 0) &&
+    if ((*score >= minscore || *score < 0) &&
         (*cheated != '*' || cheat) &&
         !stlmatch (reason, "saved") &&
         (*score > 2000 || !stlmatch (reason, "user")))

--- a/rogomatic/src/rooms.c
+++ b/rogomatic/src/rooms.c
@@ -30,6 +30,8 @@
 
 # include <curses.h>
 # include <ctype.h>
+# include <string.h>
+
 # include "types.h"
 # include "globals.h"
 
@@ -37,13 +39,21 @@
 # define EXPLORED 01
 # define HASROOM  02
 
-int levelmap[9];
+/* static declarations */
+
+static int levelmap[9];
+
+static void clearcurrect(void);
+static void teleport (void);
+static void unmarkexplored (int row, int col);
+static void connectdoors (int r1, int c1, int r2, int c2);
 
 /*
  * newlevel: Clear old data structures and set up for a new level.
  */
 
-newlevel ()
+void
+newlevel (void)
 {
   int   i, j;
 
@@ -118,9 +128,10 @@ static struct {int top,bot,left,right;} bounds[9]=
   /*8*/	 {16, 22,  53,  79}
 };
 
-markmissingrooms ()
+void
+markmissingrooms (void)
 {
-  register rm,i,j;
+  int rm, i, j;
 
   for (rm=0; rm<9; ++rm) {
     room[rm]=0;
@@ -144,10 +155,10 @@ nextroom: ;
  *		room 6 | room 7 | room 8
  */
 
-int whichroom (r,c)
-register int r,c;
+int
+whichroom (int r, int c)
 {
-  register int rm;
+  int rm;
 
   for (rm=0; rm<9; ++rm)
     if (r >= bounds[rm].top  && r <= bounds[rm].bot &&
@@ -161,10 +172,10 @@ register int r,c;
  * nametrap: look around for a trap and set its type.
  */
 
-nametrap (traptype, standingonit)
-int traptype, standingonit;
+void
+nametrap (int traptype, int standingonit)
 {
-  register int i, r, c, tdir = NONE, monsteradj = 0;
+  int i, r, c, tdir = NONE, monsteradj = 0;
 
   if (standingonit)
     { r=atrow; c=atcol; }
@@ -218,10 +229,10 @@ int traptype, standingonit;
  * findstairs: Look for STAIRS somewhere and set the stairs to that square.
  */
 
-findstairs (notr, notc)
-int notr, notc;
+void
+findstairs (int notr, int notc)
 {
-  register int r, c;
+  int r, c;
 
   stairrow = staircol = NONE;
 
@@ -236,10 +247,10 @@ int notr, notc;
  * downright: Find a square from which we cannot go down or right.
  */
 
-downright (drow, dcol)
-int *drow, *dcol;
+int
+downright (int *drow, int *dcol)
 {
-  register int i=atrow, j=atcol;
+  int i=atrow, j=atcol;
 
   while (i < 23 && j < 79) {
     if (onrc (CANGO, i, j+1)) j++;
@@ -254,7 +265,8 @@ int *drow, *dcol;
  * Try to light up the situation
  */
 
-lightroom ()
+int
+lightroom (void)
 {
   int obj;
 
@@ -277,9 +289,10 @@ lightroom ()
  * darkroom: Are we in a dark room?
  */
 
-darkroom ()
+int
+darkroom (void)
 {
-  register int dir, dir2, drow, dcol;
+  int dir, dir2, drow, dcol;
 
   if (!on (DOOR | ROOM))
     return (0);
@@ -306,7 +319,8 @@ darkroom ()
 
 static int curt, curb, curl, curr;
 
-currentrectangle ()
+void
+currentrectangle (void)
 {
   int   flags = fT + fB + fL + fR, r, c, any = 1;
 
@@ -327,25 +341,29 @@ currentrectangle ()
     while (any) {
       any = 0;
 
-      if (flags & fT)
+      if (flags & fT) {
         for (r = curt - 1, c = curl - 1; r > 0 && c > 0 && c <= curr + 1; c++)
           if (onrc (ROOM, r, c))      { curt--; any = 1; break; }
           else if (seerc ('-', r, c)) { flags &= ~fT; break; }
+      }
 
-      if (flags & fB)
+      if (flags & fB) {
         for (r = curb + 1, c = curl - 1; r > 0 && c > 0 && c <= curr + 1; c++)
           if (onrc (ROOM, r, c))      { curb++; any = 1; break; }
           else if (seerc ('-', r, c)) { flags &= ~fB; break; }
+      }
 
-      if (flags & fL)
+      if (flags & fL) {
         for (r = curt, c = curl - 1; r > 0 && c > 0 && r <= curb; r++)
           if (onrc (ROOM, r, c))      { curl--; any = 1; break; }
           else if (seerc ('|', r, c)) { flags &= ~fL; break; }
+      }
 
-      if (flags & fR)
+      if (flags & fR) {
         for (r = curt, c = curr + 1; r <= curb; r++)
           if (onrc (ROOM, r, c))      { curr++; any = 1; break; }
           else if (seerc ('|', r, c)) { flags &= ~fR; break; }
+      }
 
     }
 
@@ -399,7 +417,8 @@ currentrectangle ()
   }
 }
 
-clearcurrect()
+static void
+clearcurrect(void)
 {
   curl = curr = curt = curb = 0;
 }
@@ -411,10 +430,11 @@ clearcurrect()
  * Bug if teleported horiz or vert. Infers cango
  */
 
-updateat ()
+void
+updateat (void)
 {
-  register int dr = atrow - atrow0, dc = atcol - atcol0;
-  register int i, r, c;
+  int dr = atrow - atrow0, dc = atcol - atcol0;
+  int i, r, c;
   int   dist, newzone, sum;
 
   /*
@@ -498,11 +518,10 @@ updateat ()
  * updatepos: Something changed on the screen, update the screen map
  */
 
-updatepos (ch, row, col)
-register char  ch;
-register int row, col;
+void
+updatepos (char ch, int row, int col)
 {
-  char  oldch = screen[row][col], *monster, functionchar();
+  char  oldch = screen[row][col], *monster;
   int   seenbefore = onrc (EVERCLR, row, col);
   int   couldgo = onrc (CANGO, row, col);
   int   unseen = !onrc (SEEN, row, col);
@@ -706,9 +725,10 @@ register int row, col;
  * avoid doing silly things.
  */
 
-teleport ()
+static void
+teleport (void)
 {
-  register int r = atrow0, c = atcol0;
+  int r = atrow0, c = atcol0;
 
   goalr = goalc = NONE; setnewgoal ();
 
@@ -741,9 +761,10 @@ teleport ()
  * inferences.
  */
 
-mapinfer()
+void
+mapinfer(void)
 {
-  register r, c, inroom;
+  int r, c, inroom;
 
   dwait (D_CONTROL, "Map read: inferring rooms.");
 
@@ -765,10 +786,10 @@ mapinfer()
  * markexplored: If we are in a room, mark the location as explored.
  */
 
-markexplored (row, col)
-int row, col;
+void
+markexplored (int row, int col)
 {
-  register int rm = whichroom (row, col);
+  int rm = whichroom (row, col);
 
   if (rm != NONE && !(levelmap[rm] & EXPLORED)) {
     levelmap[rm] |= EXPLORED;
@@ -782,10 +803,10 @@ int row, col;
  * unmarkexplored: If we are in a room, unmark the location as explored.
  */
 
-unmarkexplored (row, col)
-int row, col;
+static void
+unmarkexplored (int row, int col)
 {
-  register int rm = whichroom (row, col);
+  int rm = whichroom (row, col);
 
   if (rm != NONE) levelmap[rm] &= ~EXPLORED;
 }
@@ -794,10 +815,10 @@ int row, col;
  * isexplored: If we are in a room, return true if it has been explored.
  */
 
-isexplored (row, col)
-int row, col;
+int
+isexplored (int row, int col)
 {
-  register int rm = whichroom (row, col);
+  int rm = whichroom (row, col);
 
   return (rm != NONE ? levelmap[rm] & EXPLORED : 0);
 }
@@ -806,10 +827,10 @@ int row, col;
  * haveexplored: Have we explored n rooms?
  */
 
-haveexplored (n)
-int n;
+int
+haveexplored (int n)
 {
-  register int rm, count = 0;
+  int rm, count = 0;
 
   for (rm = 0; rm < 9; rm++)
     if (levelmap[rm] & EXPLORED)
@@ -822,9 +843,10 @@ int n;
  * printexplored: List the explored rooms
  */
 
-printexplored ()
+void
+printexplored (void)
 {
-  register int rm;
+  int rm;
 
   at (0,0);
   printw ("Rooms explored: ");
@@ -853,10 +875,10 @@ printexplored ()
  * space.
  */
 
-inferhall (r, c)
-register int r, c;
+void
+inferhall (int r, int c)
 {
-  register int i, j, k;
+  int i, j, k;
 
   int inc, rm, end1, end2, end, dropout = 0, dir = NONE;
 
@@ -956,10 +978,10 @@ register int r, c;
   dwait (D_SEARCH | D_CONTROL, "Hall search done.");
 }
 
-connectdoors (r1, c1, r2, c2)
-register int r1, c1, r2, c2;
+static void
+connectdoors (int r1, int c1, int r2, int c2)
 {
-  register int r, c;
+  int r, c;
   int endr = max (r1, r2), endc = max (c1, c2);
 
   dwait (D_INFORM, "Inferring hall (%d,%d) to (%d,%d)", r1, c1, r2, c2);
@@ -970,7 +992,7 @@ register int r1, c1, r2, c2;
 
   for (r = min (r1, r2) - 1; r <= endr + 1; r++)
     for (c = min (c1, c2) - 1; c <= endc + 1; c++)
-      setrc (SEEN, r, c); 		     /* Nothing to see here */
+      setrc (SEEN, r, c);		     /* Nothing to see here */
 }
 
 /*
@@ -981,10 +1003,10 @@ register int r1, c1, r2, c2;
  * September 25, 1983	Michael L. Mauldin
  */
 
-canbedoor (deadr, deadc)
-int deadr, deadc;
+int
+canbedoor (int deadr, int deadc)
 {
-  register int r, c, dr, dc, k, count;
+  int r, c, dr, dc, k, count;
 
   /* Check all orthogonal directions around the square */
   for (k=0; k < 8; k+=2) {
@@ -1006,10 +1028,10 @@ int deadr, deadc;
  * mazedoor: Return true if this could be a door to a maze
  */
 
-mazedoor (row, col)
-int row, col;
+int
+mazedoor (int row, int col)
 {
-  register int r=row, c=col, dr, dc, k=0, dir = NONE;
+  int r=row, c=col, dr, dc, k=0, dir = NONE;
 
   if (onrc (HALL,r,c+1)) {dir=0; k++; dr=0;   dc=1;}
 
@@ -1046,18 +1068,22 @@ int row, col;
  * nextto:  Is there a square type orthogonally adjacent?
  */
 
-nextto (type,r,c)
-register int type, r, c;
+int
+nextto (int type, int r, int c)
 {
-  register int result;
+  int result;
 
-  if (result = onrc (type, r-1, c)) return (result);
+  result = onrc (type, r-1, c);
+  if (result) return (result);
 
-  if (result = onrc (type, r+1, c)) return (result);
+  result = onrc (type, r+1, c);
+  if (result) return (result);
 
-  if (result = onrc (type, r, c-1)) return (result);
+  result = onrc (type, r, c-1);
+  if (result) return (result);
 
-  if (result = onrc (type, r, c+1)) return (result);
+  result = onrc (type, r, c+1);
+  if (result) return (result);
 
   return (0);
 }
@@ -1070,8 +1096,8 @@ register int type, r, c;
  * Fuzzy:	Replaces knowisdoor (), October 17, 1983.
  */
 
-nexttowall (r,c)
-register int r, c;
+int
+nexttowall (int r, int c)
 {
   return (onrc (DOOR | WALL, r-1, c) == WALL ||
           onrc (DOOR | WALL, r+1, c) == WALL ||
@@ -1083,9 +1109,10 @@ register int r, c;
  * dumpmazedoor: Show all squares for which mazedoor(r,c) is true.
  */
 
-dumpmazedoor ()
+void
+dumpmazedoor (void)
 {
-  register int r, c;
+  int r, c;
 
   for (r=2; r<22; r++) {
     for (c=1; c<79; c++) {
@@ -1102,7 +1129,8 @@ dumpmazedoor ()
  * foundnew: Reactivate rules which new new squares to work
  */
 
-foundnew ()
+void
+foundnew (void)
 {
   new_mark = new_findroom = new_search = new_stairs = 1;
   reusepsd = teleported = 0;

--- a/rogomatic/src/scorefile.c
+++ b/rogomatic/src/scorefile.c
@@ -35,6 +35,9 @@
 # include <stdlib.h>
 # include <sys/types.h>
 # include <sys/stat.h>
+# include <unistd.h>
+# include <signal.h>
+
 # include "types.h"
 # include "globals.h"
 # include "install.h"
@@ -42,7 +45,11 @@
 # define LINESIZE	2048
 # define SCORE(s,p)     (atoi (s+p))
 
+/* static declarations */
+
 static char lokfil[100];
+
+static void intrupscore (int sig __attribute__ ((__unused__)));
 
 /*
  * add_score: Write a new score line out to the correct rogomatic score
@@ -51,9 +58,8 @@ static char lokfil[100];
  * score file and catching interrupts and things.
  */
 
-add_score (new_line, vers, ntrm)
-char *new_line, *vers;
-int ntrm;
+void
+add_score (char *new_line, char *vers, int ntrm)
 {
   int   wantscore = 1;
   char  ch;
@@ -103,12 +109,12 @@ int ntrm;
  * dumpscore: Print out the scoreboard.
  */
 
-dumpscore (vers)
-char *vers;
+void
+dumpscore (char *vers)
 {
   char  ch, scrfil[100], delfil[100], newfil[100], allfil[100], cmd[256];
   FILE *scoref, *deltaf;
-  int   oldmask, intrupscore ();
+  int   oldmask;
 
   sprintf (lokfil, "%s %s", LOCKFILE, vers);
   sprintf (scrfil, "%s/rgmscore%s", getRgmDir (), vers);
@@ -198,9 +204,9 @@ char *vers;
  * intrupscore: We have an interrupt, clean up and unlock the score file.
  */
 
-intrupscore ()
+static void
+intrupscore (int sig __attribute__ ((__unused__)))
 {
   unlock_file (lokfil);
   exit (1);
 }
-

--- a/rogomatic/src/search.c
+++ b/rogomatic/src/search.c
@@ -29,6 +29,7 @@
 
 # include <stdio.h>
 # include <curses.h>
+
 # include "types.h"
 # include "globals.h"
 
@@ -40,19 +41,28 @@
 # define NOTTRIED     (11)
 # define TARGET       (10)
 
+/* static declarations */
+
 static int moveavd[24][80], moveval[24][80], movecont[24][80],
        movedepth[24][80];
 static char mvdir[24][80];
 static int mvtype=0;
 static int didinit=0;
 
+static int validatemap (int movetype, int (*evalinit)(void),
+		       int (*evaluate)(int, int, int, int*, int*, int*));
+static int searchfrom (int row, int col,
+		       int (*evaluate)(int, int, int, int*, int*, int*), char dir[24][80], int *trow, int *tcol);
+static int searchto (int row, int col,
+		     int (*evaluate)(int, int, int, int*, int*, int*), char dir[24][80], int *trow, int *tcol);
+
 /*
  * makemove: repeat move from here towards some sort of target.
  * Modified to use findmove.			5/13	MLM
  */
 
-makemove (movetype, evalinit, evaluate, reevaluate)
-int movetype, (*evalinit)(), (*evaluate)(), reevaluate;
+int
+makemove (int movetype, int (*evalinit)(void), int (*evaluate)(int, int, int, int*, int*, int*), int reevaluate)
 {
   if (findmove (movetype, evalinit, evaluate, reevaluate))
     return (followmap (movetype));
@@ -65,8 +75,8 @@ int movetype, (*evalinit)(), (*evaluate)(), reevaluate;
  *           the correct state for validatemap or followmap to work.	MLM
  */
 
-findmove (movetype, evalinit, evaluate, reevaluate)
-int movetype, (*evalinit)(), (*evaluate)(), reevaluate;
+int
+findmove (int movetype, int (*evalinit)(void), int (*evaluate)(int, int, int, int*, int*, int*), int reevaluate)
 {
   int result;
 
@@ -113,10 +123,10 @@ int movetype, (*evalinit)(), (*evaluate)(), reevaluate;
  * May 13, MLM
  */
 
-followmap (movetype)
-register int movetype;
+int
+followmap (int movetype)
 {
-  register int dir, dr, dc, r, c;
+  int dir, dr, dc, r, c;
   int timemode, searchit, count=1;
 
   dir=mvdir[atrow][atcol]-FROM; dr=deltr[dir]; dc=deltc[dir];
@@ -197,10 +207,10 @@ register int movetype;
  * Called only by findmove.	MLM
  */
 
-validatemap (movetype, evalinit, evaluate)
-int movetype, (*evalinit)(), (*evaluate)();
+static int
+validatemap (int movetype, int (*evalinit)(void), int (*evaluate)(int, int, int, int*, int*, int*))
 {
-  register int thedir, dir, r, c;
+  int thedir, dir, r, c;
   int val, avd, cont;
 
   dwait (D_CONTROL | D_SEARCH, "Validatemap: type %d", movetype);
@@ -268,8 +278,8 @@ int movetype, (*evalinit)(), (*evaluate)();
  * cancelmove: Invalidate all stored moves of a particular type.
  */
 
-cancelmove (movetype)
-int movetype;
+void
+cancelmove (int movetype)
 {
   if (movetype == mvtype) mvtype = 0;
 }
@@ -278,7 +288,8 @@ int movetype;
  * setnewgoal: Invalidate all stored moves.
  */
 
-setnewgoal ()
+void
+setnewgoal (void)
 {
   mvtype = 0;
   goalr = goalc = NONE;
@@ -294,12 +305,10 @@ setnewgoal ()
  * arguments and results otherwise the same as searchto.	LGCH
  */
 
-searchfrom (row, col, evaluate, dir, trow, tcol)
-int row, col, *trow, *tcol;
-int (*evaluate)();
-char dir[24][80];
+static int
+searchfrom (int row, int col, int (*evaluate)(int, int, int, int*, int*, int*), char dir[24][80], int *trow, int *tcol)
 {
-  register int r, c, sdir, tempdir;
+  int r, c, sdir, tempdir;
 
   if (!searchto (row, col, evaluate, dir, trow, tcol)) {
     return (0);
@@ -345,17 +354,15 @@ char dir[24][80];
 
 /*
  * Since this code is the single most time consuming subroutine, I am
- * attempting to hack it into a faster form. 			11/6/82 MLM
+ * attempting to hack it into a faster form.			11/6/82 MLM
  */
 
-searchto (row, col, evaluate, dir, trow, tcol)
-int row, col, *trow, *tcol;
-int (*evaluate)();
-char dir[24][80];
+static int
+searchto (int row, int col, int (*evaluate)(int, int, int, int*, int*, int*), char dir[24][80], int *trow, int *tcol)
 {
   int searchcontinue = 10000000, type, havetarget=0, depth=0;
-  register int r, c, nr, nc;
-  register int k;
+  int r, c, nr, nc;
+  int k;
   char begin[QSIZE], *end, *head, *tail;
   int saveavd[24][80], val, avd, cont;
   int any;
@@ -461,7 +468,7 @@ char dir[24][80];
 
     while (1) {
       for (k=0; k<8; k++) {
-        register int S;
+        int S;
 
         /* examine adjacent squares. */
         nr = r + sdeltr[k];

--- a/rogomatic/src/setup.c
+++ b/rogomatic/src/setup.c
@@ -31,6 +31,8 @@
 # include <stdlib.h>
 # include <signal.h>
 # include <unistd.h>
+
+# include "types.h"
 # include "install.h"
 
 # define READ    0
@@ -40,12 +42,15 @@
 
 # define ROGUETERM "rg|rterm:am:bs:ce=^[^S:cl=^L:cm=^[a%+ %+ :co#80:li#24:so=^[D:se=^[d:pt:ta=^I:up=^[;:db:xn:"
 
-int   frogue, trogue;
+/* static declarations */
 
-main (argc, argv)
-int   argc;
-char *argv[];
+static int   frogue, trogue;
 
+static void replaylog (char *fname, char *options);
+static int author (void);
+
+int
+main (int argc, char *argv[])
 {
   int   ptc[2], ctp[2];
   int   child, score = 0, oldgame = 0;
@@ -179,8 +184,8 @@ char *argv[];
  * given the fake value 'Z'.
  */
 
-replaylog (fname, options)
-char *fname, *options;
+static void
+replaylog (char *fname, char *options)
 {
   execl ("player", "player", "ZZ", "0", options, fname, 0);
 # ifdef PLAYER
@@ -195,7 +200,8 @@ char *fname, *options;
  *	See if a user is an author of the program
  */
 
-author()
+static int
+author (void)
 {
   switch (getuid()) {
     case 1337:	/* Fuzzy */

--- a/rogomatic/src/stats.c
+++ b/rogomatic/src/stats.c
@@ -48,14 +48,15 @@
 
 # include <stdio.h>
 # include <math.h>
+
 # include "types.h"
 
 /*
  * clearprob: zero a probability structure.
  */
 
-clearprob (p)
-register  probability *p;
+void
+clearprob (probability *p)
 {
   p->fail = p->win = 0;
 }
@@ -64,9 +65,8 @@ register  probability *p;
  * addprob: Add a data point to a probability
  */
 
-addprob (p, success)
-register probability *p;
-register int success;
+void
+addprob (probability *p, int success)
 {
   if (success)	p->win++;
   else		p->fail++;
@@ -76,10 +76,10 @@ register int success;
  * prob: Calculate a probability
  */
 
-double prob (p)
-register probability *p;
+double
+prob (probability *p)
 {
-  register int trials = p->fail + p->win;
+  int trials = p->fail + p->win;
 
   if (trials < 1)	return (0.0);
   else			return ((double) p->win / trials);
@@ -89,9 +89,8 @@ register probability *p;
  * parseprob: Parse a probability structure from buffer 'buf'
  */
 
-parseprob (buf, p)
-register char *buf;
-register probability *p;
+void
+parseprob (char *buf, probability *p)
 {
   p->win = p->fail = 0;
   sscanf (buf, "%d %d", &p->fail, &p->win);
@@ -101,9 +100,8 @@ register probability *p;
  * writeprob. Write the value of a probability structure to file 'f'.
  */
 
-writeprob (f, p)
-register FILE *f;
-register probability *p;
+void
+writeprob (FILE *f, probability *p)
 {
   fprintf (f, "%d %d", p->fail, p->win);
 }
@@ -112,8 +110,8 @@ register probability *p;
  * clearstat: zero a statistic structure.
  */
 
-clearstat (s)
-register  statistic * s;
+void
+clearstat (statistic *s)
 {
   s->count = 0;
   s->sum = s->sumsq = s->low = s->high = 0.0;
@@ -123,9 +121,8 @@ register  statistic * s;
  * addstat: Add a data point to a statistic
  */
 
-addstat (s, datum)
-register statistic *s;
-register int datum;
+void
+addstat (statistic *s, int datum)
 {
   double d = (double) datum;
 
@@ -142,8 +139,8 @@ register int datum;
  * mean: Return the mean of a statistic
  */
 
-double mean (s)
-register statistic *s;
+double
+mean (statistic *s)
 {
   if (s->count < 1)	return (0.0);
   else			return (s->sum / s->count);
@@ -153,10 +150,10 @@ register statistic *s;
  * stdev: Return the standard deviation of a statistic
  */
 
-double stdev (s)
-register statistic *s;
+double
+stdev (statistic *s)
 {
-  register n = s->count;
+  int n = s->count;
 
   if (n < 2)	return (0.0);
   else		return (sqrt ((n * s->sumsq - s->sum * s->sum) / (n * (n-1))));
@@ -166,9 +163,8 @@ register statistic *s;
  * parsestat: Parse a statistic structure from buffer 'buf'
  */
 
-parsestat (buf, s)
-register char *buf;
-register statistic *s;
+void
+parsestat (char *buf, statistic *s)
 {
   s->count = 0;
   s->sum = s->sumsq = s->low = s->high = 0.0;
@@ -180,9 +176,8 @@ register statistic *s;
  * writestat. Write the value of a statistic structure to file 'f'.
  */
 
-writestat (f, s)
-register FILE *f;
-register statistic *s;
+void
+writestat (FILE *f, statistic *s)
 {
   fprintf (f, "%d %lg %lg %lg %lg",
            s->count, s->sum, s->sumsq, s->low, s->high);

--- a/rogomatic/src/survival.c
+++ b/rogomatic/src/survival.c
@@ -38,6 +38,7 @@
 # include <stdio.h>
 # include <ctype.h>
 # include <curses.h>
+
 # include "types.h"
 # include "globals.h"
 
@@ -52,6 +53,10 @@
     if (stand) standend ();			\
     refresh (); }
 
+/* static declarations */
+
+static void markchokepts (void);
+
 /*
  * markcycles: evokes fond memories of an earlier time, when Andrew
  * was a hacker who just patched things together until they worked,
@@ -62,11 +67,12 @@
  * runaway code.
  */
 
-markcycles (print)
+int
+markcycles (int print)
 {
   short mark[1920];
   struct {short where,door,dirs;} st[1000];
-  register int sp,newsquare; int *Scr; int whichdir; int D;
+  int sp,newsquare; int *Scr; int whichdir; int D;
 
   if (!new_mark) return (0);
 
@@ -74,7 +80,7 @@ markcycles (print)
 
   markchokepts ();
 
-  { register int count=1920; register short *m=mark; while(count--) *m++=0;}
+  { int count=1920; short *m=mark; while(count--) *m++=0;}
   sp=1; st[1].where=atrow*80+atcol; st[1].dirs=1; st[1].door=0;
 
   for (D = 0; D < 8; D += 2) {
@@ -105,7 +111,7 @@ markcycles (print)
         /* whichdir is 6,2, or 4. */
         if ((Scr[newsquare= (st[sp].where+deltrc[(whichdir+D)&7])])&CANGO) {
           if (mark[newsquare]) {
-            register int stop,i;
+            int stop,i;
 
             if (mark[newsquare]<sp) {
               for (stop=st[mark[newsquare]].door,
@@ -148,14 +154,15 @@ markcycles (print)
  * Added: 3/7/87 by mlm
  */
 
-markchokepts ()
+static void
+markchokepts (void)
 {
-  register int *Scr, *ScrEnd, loc;
+  int *Scr, *ScrEnd, loc;
 
   for (Scr = scrmap[0], ScrEnd = &Scr[1920]; Scr<ScrEnd; Scr++) {
     if (*Scr & DOOR) *Scr |= CHOKE;
     else if (*Scr & HALL) {
-      register int nbrs = 0, k;
+      int nbrs = 0, k;
 
       for (k=0; k<8; k++)
         { if (Scr[deltrc[k]] & CANGO) nbrs++; }
@@ -168,7 +175,7 @@ markchokepts ()
         *Scr |= CHOKE;
 
         if (debug (D_SCREEN)) {
-          register int rowcol = Scr - scrmap[0];
+          int rowcol = Scr - scrmap[0];
           standout ();
           mvprintw (rowcol/80, rowcol%80, "C");
           standend ();
@@ -182,7 +189,8 @@ markchokepts ()
  * Runaway: Panic!
  */
 
-int runaway ()
+int
+runaway (void)
 {
   if (on (SCAREM)) {
     dwait (D_BATTLE, "Not running, on scare monster scroll!");
@@ -204,10 +212,10 @@ int runaway ()
  * Canrun: set up a move which will get us away from danger.
  */
 
-int canrun ()
+int
+canrun (void)
 {
   int result, oldcomp = compression;
-  int runinit(), runvalue(), expruninit(), exprunvalue();
 
   if (on (STAIRS)) return (1);		/* Can run down stairs */
 
@@ -228,11 +236,10 @@ int canrun ()
  *		"The Love Song of J. Alfred Prufrock", T.S. Eliot
  */
 
-int unpin ()
+int
+unpin (void)
 {
   int result, oldcomp = compression;
-  int unpininit (), runvalue (), expunpininit (),
-      exprunvalue (), expunpinvalue ();
 
   if (on (SCAREM)) {
     dwait (D_BATTLE, "Not unpinning, on scare monster scroll!");
@@ -262,10 +269,9 @@ int unpin ()
  *             door.
  */
 
-int backtodoor (dist)
-int dist;
+int
+backtodoor (int dist)
 {
-  int rundoorinit(), rundoorvalue();
   static int lastcall= -10, stillcount=0, notmoving=0, closest=99;
 
   /*

--- a/rogomatic/src/things.c
+++ b/rogomatic/src/things.c
@@ -29,15 +29,21 @@
 
 # include <ctype.h>
 # include <curses.h>
+# include <string.h>
+
 # include "types.h"
 # include "globals.h"
+
+/* static declarations */
+
+static int destroyjunk (int obj);
 
 /*
  * wear: This primitive function issues a command to put on armor.
  */
 
-wear (obj)
-int obj;
+int
+wear (int obj)
 {
   if (currentarmor != NONE) {
     dwait (D_FATAL, "Trying to put on a second coat of armor");
@@ -55,7 +61,8 @@ int obj;
  * takeoff: Remove the current armor.
  */
 
-takeoff ()
+int
+takeoff (void)
 {
   if (currentarmor == NONE) {
     dwait (D_ERROR, "Trying to take off armor we don't have on!");
@@ -73,8 +80,8 @@ takeoff ()
  * wield: This primitive function issues a command to wield a weapon.
  */
 
-wield (obj)
-int obj;
+int
+wield (int obj)
 {
   if (cursedweapon) return (0);
 
@@ -124,8 +131,8 @@ int obj;
  *           removed from the game (adapted from dropjunk).
  */
 
-destroyjunk (obj)
-int obj;
+static int
+destroyjunk (int obj)
 {
 
   if ((obj != NONE) && (gotocorner () || throw (obj, 7)))
@@ -139,8 +146,8 @@ int obj;
  * and returns 1 if it wins and 0 if it fails.
  */
 
-drop (obj)
-int obj;
+int
+drop (int obj)
 {
   /* Can't if not there, in use, or on something else or
      dropped something else already */
@@ -191,8 +198,8 @@ int obj;
  * quaff: build and send a quaff potion command.
  */
 
-quaff (obj)
-int obj;
+int
+quaff (int obj)
 {
   if (inven[obj].type != potion) {
     dwait (D_ERROR, "Trying to quaff %c", LETTER (obj));
@@ -208,8 +215,8 @@ int obj;
  * reads: build and send a read scroll command.
  */
 
-reads (obj)
-int obj;
+int
+reads (int obj)
 {
   if (inven[obj].type != Scroll) {
     dwait (D_ERROR, "Trying to read %c", LETTER (obj));
@@ -225,8 +232,8 @@ int obj;
  * build and send a point with wand command.
  */
 
-point (obj, dir)
-int obj, dir;
+int
+point (int obj, int dir)
 {
   if (inven[obj].type != wand) {
     dwait (D_ERROR, "Trying to point %c", LETTER (obj));
@@ -247,8 +254,8 @@ int obj, dir;
  * throw: build and send a throw object command.
  */
 
-throw (obj, dir)
-int obj, dir;
+int
+throw (int obj, int dir)
 {
   if (obj < 0 || obj >= invcount) {
     dwait (D_ERROR, "Trying to throw %c", LETTER (obj));
@@ -263,8 +270,8 @@ int obj, dir;
  * puton: build and send a command to put on a ring.
  */
 
-puton (obj)
-int obj;
+int
+puton (int obj)
 {
   if (leftring == NONE && rightring == NONE)
     { command (T_HANDLING, "P%cl", LETTER (obj)); return (1); }
@@ -279,8 +286,8 @@ int obj;
  * removering: build a command to remove a ring. It is left in the pack.
  */
 
-removering (obj)
-int obj;
+int
+removering (int obj)
 {
   if (leftring != NONE && rightring != NONE && leftring == obj)
     { command (T_HANDLING, "Rl"); return (1); }
@@ -298,7 +305,8 @@ int obj;
  * initstufflist: clear the list of objects on this level.
  */
 
-initstufflist ()
+void
+initstufflist (void)
 {
   slistlen = 0;
 }
@@ -307,9 +315,8 @@ initstufflist ()
  * addstuff: add an item to the list of items on this level.
  */
 
-addstuff (ch, row, col)
-char  ch;
-int   row, col;
+void
+addstuff (char ch, int row, int col)
 {
   /* if (seerc ('@', row, col)) return (0); */ /* Removed MLM 10/28/83 */
   if (onrc (STUFF, row, col))
@@ -328,10 +335,10 @@ int   row, col;
  * deletestuff: remove the object from the stuff list at location (x,y)
  */
 
-deletestuff (row, col)
-int   row, col;
+void
+deletestuff (int row, int col)
 {
-  register int   i;
+  int   i;
   unsetrc (STUFF, row, col);
 
   for (i = 0; i < slistlen; ++i)
@@ -345,9 +352,10 @@ int   row, col;
  * dumpstuff: (debugging) dump the list of objects on this level.
  */
 
-dumpstuff ()
+void
+dumpstuff (void)
 {
-  register int   i;
+  int   i;
   at (1, 0);
 
   for (i = 0; i < slistlen; ++i)
@@ -363,8 +371,8 @@ dumpstuff ()
  * display: Print a message on line 1 of the screen.
  */
 
-display (s)
-char *s;
+void
+display (char *s)
 {
   saynow (s);
   msgonscreen=1;
@@ -374,8 +382,8 @@ char *s;
  * prepareident: Set nextid and afterid to proper values
  */
 
-prepareident (obj, iscroll)
-int obj, iscroll;
+int
+prepareident (int obj, int iscroll)
 {
   nextid = LETTER (obj);
   afterid = (iscroll > obj || inven[iscroll].count > 1) ? nextid : nextid-1;
@@ -388,9 +396,10 @@ int obj, iscroll;
  * first item in the pack).
  */
 
-int pickident ()
+int
+pickident (void)
 {
-  register int obj;
+  int obj;
 
   if      ((obj=unknown      (ring))   != NONE);
   else if ((obj=unidentified (wand))   != NONE);
@@ -408,10 +417,10 @@ int pickident ()
  * unknown: Return the index of any unknown object of type otype
  */
 
-int unknown (otype)
-stuff otype;
+int
+unknown (stuff otype)
 {
-  register int i;
+  int i;
 
   for (i=0; i<invcount; ++i)
     if (inven[i].count &&
@@ -426,10 +435,10 @@ stuff otype;
  * unidentified: Return the index of any unidentified object of type otype
  */
 
-int unidentified (otype)
-stuff otype;
+int
+unidentified (stuff otype)
 {
-  register int i;
+  int i;
 
   for (i=0; i<invcount; ++i)
     if (inven[i].count &&
@@ -446,11 +455,10 @@ stuff otype;
  * but not 'other'.
  */
 
-int haveother (otype,other)
-stuff otype;
-int other;
+int
+haveother (stuff otype, int other)
 {
-  register int i;
+  int i;
 
   for (i=0; i<invcount; ++i)
     if (inven[i].count &&
@@ -466,10 +474,10 @@ int other;
  * have: Return the index of any object of type otype
  */
 
-int have (otype)
-stuff otype;
+int
+have (stuff otype)
 {
-  register int i;
+  int i;
 
   for (i=0; i<invcount; ++i)
     if (inven[i].count &&
@@ -483,11 +491,10 @@ stuff otype;
  * name which is not in use .
  */
 
-int havenamed (otype,name)
-stuff otype;
-char *name;
+int
+havenamed (stuff otype, char *name)
 {
-  register int i;
+  int i;
 
   for (i=0; i<invcount; ++i)
     if (inven[i].count &&
@@ -503,10 +510,10 @@ char *name;
  * havewand: Return the index of a charged wand or staff
  */
 
-int havewand (name)
-char *name;
+int
+havewand (char *name)
 {
-  register int i;
+  int i;
 
   /* Find one with positive charges */
   for (i=0; i<invcount; ++i)
@@ -531,10 +538,10 @@ char *name;
  * wearing: Return the index if wearing a ring with this title
  */
 
-wearing (name)
-char *name;
+int
+wearing (char *name)
 {
-  register int result = NONE;
+  int result = NONE;
 
   if (leftring != NONE && itemis (leftring, INUSE) &&
       streq (inven[leftring].str, name))
@@ -553,12 +560,10 @@ char *name;
  * last of something .
  */
 
-int havemult (otype, name, count)
-stuff otype;
-char *name;
-int   count;
+int
+havemult (stuff otype, char *name, int count)
 {
-  register int i, num=count;
+  int i, num=count;
 
   for (i=0; i<invcount; ++i)
     if (inven[i].count &&
@@ -575,9 +580,10 @@ int   count;
  * (used to throw away stuff at end)
  */
 
-int haveminus ()
+int
+haveminus (void)
 {
-  register int i;
+  int i;
 
   for (i=0; i<invcount; ++i)
     if (inven[i].count &&
@@ -605,9 +611,10 @@ int haveminus ()
  *   and if all those fail return NONE
  */
 
-int haveuseless ()
+int
+haveuseless (void)
 {
-  register int i;
+  int i;
 
   for (i=0; i<invcount; ++i) {
     if (inven[i].count > 0) {
@@ -662,8 +669,8 @@ int haveuseless ()
  * willrust: return true if a suit of armor can rust
  */
 
-willrust (obj)
-int obj;
+int
+willrust (int obj)
 {
   return (! (protected ||
              armorclass (obj) > 8 || armorclass (obj) < -5 ||
@@ -675,8 +682,8 @@ int obj;
  * wielding: return true if we are wielding an object of type 'otype'
  */
 
-wielding (otype)
-stuff otype;
+int
+wielding (stuff otype)
 {
   return (inven[currentweapon].type == otype);
 }
@@ -685,22 +692,31 @@ stuff otype;
  * hungry: return true if we are hungry, weak, or fainting
  */
 
-hungry ()
-{ return (*Ms == 'H' || *Ms == 'W' || *Ms == 'F'); }
+int
+hungry (void)
+{
+  return (*Ms == 'H' || *Ms == 'W' || *Ms == 'F');
+}
 
 /*
  * weak: return true if we are weak or fainting
  */
 
-weak ()
-{ return (*Ms == 'W' || *Ms == 'F'); }
+int
+weak (void)
+{
+  return (*Ms == 'W' || *Ms == 'F');
+}
 
 /*
  * fainting: return true if we are fainting
  */
 
-fainting ()
-{ return (*Ms == 'F'); }
+int
+fainting (void)
+{
+  return (*Ms == 'F');
+}
 
 /*
  * havefood: return true if we have more than 'n' foods, modified
@@ -708,8 +724,8 @@ fainting ()
  * routine returns true less often).
  */
 
-int havefood (n)
-int n;
+int
+havefood (int n)
 {
   int remaining, foodest, desired;
 

--- a/rogomatic/src/titlepage.c
+++ b/rogomatic/src/titlepage.c
@@ -31,8 +31,11 @@
 
 # include <stdio.h>
 # include <curses.h>
+
 # include "types.h"
 # include "globals.h"
+
+/* static declarations */
 
 static char *titlepage[]= {
   /* The static part of the display */
@@ -78,6 +81,8 @@ static char *titlepage[]= {
   NULL
 };
 
+static void animate (char *movie[]);
+
 # define NEXTCHAR (*cbf?*cbf++:(cbf=1+ *movie++)[-1])
 
 /*
@@ -90,12 +95,12 @@ static char *titlepage[]= {
  * greater than 2400).
  */
 
-animate (movie)
-char *movie[];
+static void
+animate (char *movie[])
 {
   int baud;
-  register int r, c, count = 0, delaychars;
-  register char *cbf = "";
+  int r, c, count = 0, delaychars;
+  char *cbf = "";
 
   if (emacs || terse) return;		/* No screen ==> no movie */
 
@@ -142,13 +147,13 @@ char *movie[];
  * 'nohalf' is true if the user does not want to see a halftime show.
  */
 
-halftimeshow (level)
-int level;
+void
+halftimeshow (int level)
 {
   static int nextshow = 1;
 
   if (!nohalf && level >= nextshow) {
-    if (nextshow == 1) { 
+    if (nextshow == 1) {
       nextshow = 9999; animate (titlepage);
     }
   }

--- a/rogomatic/src/types.h
+++ b/rogomatic/src/types.h
@@ -185,7 +185,7 @@
 # define T_LISTLEN   (10)
 
 /* Bit value for debugging types (for debugging function dwait and
-   screen message debugging).  If D_MESSAGE is set the screen must 
+   screen message debugging).  If D_MESSAGE is set the screen must
    be at least 31x80 information displayed to fit.  */
 
 # define D_FATAL   (00001)
@@ -359,3 +359,319 @@ typedef struct {
   int activity[T_LISTLEN];
   int timestamp;
 } timerec;
+
+extern char *knob_name[MAXKNOB];
+extern char genelog[100];
+extern char genepool[100];
+
+/*
+ * global function declarations
+ */
+
+/* arms.c */
+extern int havearmor (int k, int print, int rustproof);
+extern int armorclass (int i);
+extern int haveweapon (int k, int print);
+extern int weaponclass (int i);
+extern int havering (int k, int print);
+extern int ringclass (int i);
+extern int havebow (int k, int print);
+extern int bowclass (int i);
+extern int havemissile (void);
+extern int havearrow (void);
+extern void setbonuses(void);
+
+/* command.c */
+extern void move1 (int d);
+extern void fmove (int d);
+extern void rmove (int count, int d, int mode);
+extern void mmove (int d, int mode);
+extern void command (int tmode, char *f, ...);
+extern char functionchar (char *cmd);
+extern int replaycommand (void);
+extern void showcommand (char *cmd);
+
+/* config.c */
+extern const char *getRgmDir (void);
+extern const char *getLockFile (void);
+
+/* database.c */
+extern int findentry (char *string);
+extern char *findentry_getfakename (char *string, stuff item_type);
+extern char *findentry_getrealname (char *string, stuff item_type);
+extern void addobj (char *codename, int pack_index, stuff item_type);
+extern void useobj (char *string);
+extern void infername (char *codename, char *name, stuff item_type);
+extern int used (char *codename);
+extern int know (char *name);
+extern void dumpdatabase (void);
+
+/* debug.c */
+extern int dwait(int msgtype, char *f, ...);
+extern void promptforflags (void);
+extern void timehistory (FILE *f, char sep);
+extern void toggledebug (void);
+
+/* debuglog.c */
+extern void debuglog_open (const char *log);
+extern void debuglog_close (void);
+extern void debuglog (const char *fmt, ...);
+
+/* explore.c */
+extern int genericinit (void);
+extern int gotowards (int r, int c, int running);
+extern int sleepvalue (int r, int c, int depth __attribute__ ((__unused__)),
+		       int *val, int *avd, int *cont __attribute__ ((__unused__)));
+extern int setpsd (int print);
+extern int downvalue (int r, int c, int depth __attribute__ ((__unused__)),
+		      int *val, int *avd, int *cont __attribute__ ((__unused__)));
+extern int expruninit (void);
+extern int exprunvalue (int r, int c, int depth, int *val, int *avd, int *cont);
+extern int expunpininit (void);
+extern int expunpinvalue (int r, int c, int depth, int *val, int *avd, int *cont);
+extern int runinit (void);
+extern int runvalue (int r, int c, int depth, int *val, int *avd, int *cont);
+extern int unpininit (void);
+extern int rundoorinit (void);
+extern int rundoorvalue (int r, int c, int depth , int *val, int *avd, int *cont);
+extern int secret (void);
+extern int findroom (void);
+extern int exploreroom (void);
+extern int doorexplore(void);
+extern int findsafe(void);
+extern int archmonster (int m, int trns);
+extern void unrest (void);
+extern int movetorest (void);
+
+/* findscore.c */
+extern int findscore (char *rogue, char *roguename);
+
+/* getroguetoken.c */
+extern int rogue_log_open (const char *filename);
+extern void rogue_log_close (void);
+extern void rogue_log_write_command (char c);
+extern void open_frogue_debuglog (const char *file);
+extern void close_frogue_debuglog (void);
+extern void open_frogue_fd (int frogue_fd);
+extern char getroguetoken (void);
+extern void getoldcommand (char *s);
+
+/* io.c */
+extern void getrogue (char *waitstr, int onat);
+extern void terpbot (void);
+extern void dumpwalls (void);
+extern void sendnow (char *f, ...);
+extern void rogo_send (char *f, ...);
+extern int resend (void);
+extern void at (int r, int c);
+extern void quitrogue (char *reason, int gld, int terminationtype);
+extern void waitfor (char *mess);
+extern void say (char *f, ...);
+extern void saynow (char *f, ...);
+extern void givehelp (void);
+extern void pauserogue (void);
+extern void getrogver (void);
+extern int charsavail (void);
+extern void redrawscreen (void);
+extern void toggleecho (void);
+extern void clearsendqueue (void);
+extern void startreplay (FILE **logf, char *logfname);
+extern void printsnap (FILE *f);
+extern void dosnapshot (void);
+extern void clearscreen (void);
+extern char *statusline (void);
+
+/* learn.c */
+extern void initpool (int k, int m);
+extern void analyzepool (int full);
+extern void setknobs (int *newid, int *knb, int *best, int *avg);
+extern void evalknobs (int gid, int score, int level);
+extern FILE *rogo_openlog (char *genelog);
+extern void rogo_closelog (void);
+extern int readgenes (char *genepool);
+extern void writegenes (char *genepool);
+
+/* ltm.c */
+extern void mapcharacter (char ch, char *str);
+extern int addmonhist (char *monster);
+extern int findmonster (char *monster);
+extern void saveltm (int score);
+extern void restoreltm (void);
+extern void dumpmonstertable (void);
+extern void analyzeltm (void);
+
+/* mess.c */
+extern void terpmes (void);
+extern void infer (char *objname, stuff item_type);
+extern void killed (char *monster);
+extern void summary (FILE *f, char sep);
+extern void versiondep (void);
+
+/* monsters.c */
+extern char *monname (char m);
+extern void addmonster (char ch, int r, int c, int quiescence);
+extern void deletemonster (int r, int c);
+extern void dumpmonster (void);
+extern void sleepmonster (void);
+extern void holdmonsters (void);
+extern void wakemonster (int dir);
+extern int seemonster (char *monster);
+extern int seeawakemonster (char *monster);
+extern int monsternum (char *monster);
+extern void newmonsterlevel (void);
+extern int isholder (char *monster);
+
+/* pack.c */
+extern char *itemstr (int i);
+extern void dumpinv (FILE *f);
+extern void removeinv (int pos);
+extern void deleteinv (int pos);
+extern void resetinv(void);
+extern void doresetinv (void);
+extern int inventory (char *msgstart, char *msgend);
+
+/* rand.c */
+extern void rogo_srand (int seed);
+extern int rogo_rand (void);
+extern int rogo_randint (int max);
+
+/* replay.c */
+extern void positionreplay (void);
+
+/* rooms.c */
+extern void newlevel (void);
+extern void markmissingrooms (void);
+extern int whichroom (int r, int c);
+extern void nametrap (int traptype, int standingonit);
+extern void findstairs (int notr, int notc);
+extern int downright (int *drow, int *dcol);
+extern int lightroom (void);
+extern int darkroom (void);
+extern void currentrectangle (void);
+extern void updateat (void);
+extern void updatepos (char ch, int row, int col);
+extern void mapinfer(void);
+extern void markexplored (int row, int col);
+extern int isexplored (int row, int col);
+extern int haveexplored (int n);
+extern void printexplored (void);
+extern void inferhall (int r, int c);
+extern int canbedoor (int deadr, int deadc);
+extern int mazedoor (int row, int col);
+extern int nextto (int type, int r, int c);
+extern int nexttowall (int r, int c);
+extern void dumpmazedoor (void);
+extern void foundnew (void);
+
+/* search.c */
+extern int makemove (int movetype, int (*evalinit)(void), int (*evaluate)(int, int, int, int*, int*, int*), int reevaluate);
+extern int findmove (int movetype, int (*evalinit)(void), int (*evaluate)(int, int, int, int*, int*, int*), int reevaluate);
+extern int followmap (int movetype);
+extern void cancelmove (int movetype);
+extern void setnewgoal (void);
+
+/* scorefile.c */
+extern void add_score (char *new_line, char *vers, int ntrm);
+extern void dumpscore (char *vers);
+
+/* strategy.c */
+extern int strategize (void);
+
+/* stats.c */
+extern void clearprob (probability *p);
+extern void addprob (probability *p, int success);
+extern double prob (probability *p);
+extern void parseprob (char *buf, probability *p);
+extern void writeprob (FILE *f, probability *p);
+extern void clearstat (statistic *s);
+extern void addstat (statistic *s, int datum);
+extern double mean (statistic *s);
+extern double stdev (statistic *s);
+extern void parsestat (char *buf, statistic *s);
+extern void writestat (FILE *f, statistic *s);
+
+/* survival.c */
+extern int markcycles (int print);
+extern int runaway (void);
+extern int canrun (void);
+extern int unpin (void);
+extern int backtodoor (int dist);
+
+/* tactics.c */
+extern int handlearmor (void);
+extern int handleweapon (void);
+extern int quaffpotion (void);
+extern int readscroll (void);
+extern int handlering (void);
+extern int findring (char *name);
+extern int grope (int turns);
+extern int findarrow (void);
+extern int checkcango (int dir, int turns);
+extern int godownstairs (int running);
+extern int plunge (void);
+extern int goupstairs (int running);
+extern int restup (void);
+extern int gotowardsgoal (void);
+extern int gotocorner (void);
+extern int light (void);
+extern int shootindark (void);
+extern int dinnertime (void);
+extern int trywand (void);
+extern int eat (void);
+
+/* things.c */
+extern int wear (int obj);
+extern int takeoff (void);
+extern int wield (int obj);
+extern int drop (int obj);
+extern int quaff (int obj);
+extern int reads (int obj);
+extern int point (int obj, int dir);
+extern int throw (int obj, int dir);
+extern int puton (int obj);
+extern int removering (int obj);
+extern void initstufflist (void);
+extern void addstuff (char ch, int row, int col);
+extern void deletestuff (int row, int col);
+extern void dumpstuff (void);
+extern void display (char *s);
+extern int prepareident (int obj, int iscroll);
+extern int pickident (void);
+extern int unknown (stuff otype);
+extern int unidentified (stuff otype);
+extern int haveother (stuff otype, int other);
+extern int have (stuff otype);
+extern int havenamed (stuff otype, char *name);
+extern int havewand (char *name);
+extern int wearing (char *name);
+extern int havemult (stuff otype, char *name, int count);
+extern int haveminus (void);
+extern int haveuseless (void);
+extern int willrust (int obj);
+extern int wielding (stuff otype);
+extern int hungry (void);
+extern int weak (void);
+extern int fainting (void);
+extern int havefood (int n);
+
+/* titlepage.c */
+extern void halftimeshow (int level);
+
+/* utility.c */
+extern int rogo_baudrate (void);
+extern char *getname (void);
+extern FILE *wopen(char *fname, char *mode);
+extern int fexists (char *fn);
+extern int filelength (char *f);
+extern void critical (void);
+extern void uncritical (void);
+extern void reset_int (void);
+extern void int_exit (void (*exitproc)(int));
+extern int lock_file (const char *lokfil, int maxtime);
+extern void unlock_file (const char *lokfil);
+extern void quit (int code, char *fmt, ...);
+extern int stlmatch (char *big, char *small);
+
+/* worth.c */
+extern int worth (int obj);
+extern int useless (int i);

--- a/rogomatic/src/worth.c
+++ b/rogomatic/src/worth.c
@@ -34,10 +34,13 @@
  */
 
 # include <curses.h>
+
 # include "types.h"
 # include "globals.h"
 
-int   objval[] = {
+/* static declarations */
+
+static int   objval[] = {
   /* strange */      0,
   /* food */       900,
   /* potion */     500,
@@ -53,8 +56,8 @@ int   objval[] = {
   /* none */         0
 };
 
-worth (obj)
-int obj;
+int
+worth (int obj)
 {
   int value, w;
 
@@ -147,8 +150,8 @@ int obj;
  * object is of no use. Used by worth to set value to 0.
  */
 
-useless (i)
-int i;
+int
+useless (int i)
 {
   /* Not useless if we are using it */
   if (itemis (i, INUSE))


### PR DESCRIPTION
This large diff is intended to upgrade the C code to be error and warning free for both the current gcc and clang compilers.  As of this Pull Request they default to the gnu17 / ISO C17 standards.

A significant amount of the work was to transform traditional K&R style function declarations into those that confirm to at least the gnu17 / ISO C17 standards.

Those functions that are called across C source files are declared as `extern` in ``rogomatic(6)`/src/types.h`.  Those functions that are declared AND used exclusively in their C  source file are declared `static`, with a forward declaration above the top most function in the file. The order that `extern` functions appear in ``rogomatic(6)`/src/types.h` and the order that `static` functions appear above the top most function represents the order that such functions appear in the file.

The trend of future c2x C compilers is to **NOT** support compiling code that uses K&R style function declarations.  And while I **strongly disagree** with that compiler decision, I also recognize that unless the `rogomatic(6)` C code is updated to at least the gnu17 / ISO C17 standards, people in the future will **NOT** be able to compile `rogomatic(6)`!

While these changes are extensive, touching every C file and nearly every C function (a few where non-K&R already), **great care** was made to **NOT** change the way that the code worked.  Even though our code inspection uncovered bugs that are likely to cause memory leaks and array bounds violations and other things that could cause `rogomatic(6)` to crash, I resisted the urge to fix such things in the Pull Request.

Is a few situations, a disturbing situation was encountered where a function returned `void` and yet a pointer to that function was used as a argument to another function that expected the function being pointed at to return some value.  For example a function execution falls into the bottom without a return while the pointer to that function, used elsewhere expected an `int` to be returned!  This "implied int" return is undefined (meaning that the C compiler was free to make up something).  I looked at similar functions that did have explicit returns, looked at where the pointer to the problematic function was called, and used our judgment to add an explicit return.  In the case of the `int`, `return (1)` as added. I expect that "function returns, function does not return" is one source of "_j-random_" crashes.

There were a number of cases where a function is declare in another function without any function type args.  Those declarations had to be removed because they were "K&R" in style **AND** conflicted with the `extern` declarations that was added to `types.h'.

In a few other situations, a function was declared `static int` when that function did not return a value.  In such cases the function was re-declared `static void`.

In some other situations, I add to add explicit braces to avoid dangling else.

There were a number of cases where a libc function was declared in the code (usually K&R in style) that at best duplicates the libc function found in a system include file, or too often overrides and/or conflicts with system include file.  In cases where the code conflicts with system include file (and usually where the proper system include file is **NOT** included in the C file), the libc function may be improperly called and/or values returned.  In such cases, the result is likely problematic to a working `rogomatic(6)`!

In yet other situations, a function as called with the wrong number of arguments even though that function has a fixed number of args! This resulted in the called function using improperly passed data It is worth noting that the this is an example of why ignoring a compiler warning may be a bad idea.  In one case, the effect was that `rogomatic(6)` treated a "blank scroll" as it were some other type of stuff, the type being whatever was grabbed from the stack.

In cases where a variable was declared in a C source file and yet the variable was exclusively in just that C source file, the variable was declared `static` to that file.

In cases where a variable was declared without a type, the type of variable was added to that declaration.

In cases where a global variable was initialized more than once (!) (thankfully to the same value), duplicate initialization was removed.

There was a few cases where a variable was declared as an `extern` and yet was only used within a single C source file.  Worse yet there were cases when a variable of the same name was used as a locally scoped variable within a C function in a different file!

There were a few cases where a local variable was declared that was the same as a #defined token, so I had to disambiguate.  For example, in a few cases a variable `min` was renamed to `minscore` in order to avoid conflict with a `min()` macro.

In cases where C function arg was `/* ARGSUSED */` or where the C function arg was simply unused, the C standard  `__attribute__ ((__unused__))` mechanism was used to declare the arg.  In cases where the K&R style arg declaration had a comment, a comment above the C function containing both the arg name and the comment was added.

As part of the C code modernization, I converted some C functions to use the `<stdarg.h>` convention.  Rather than use `<vararg.h>` (which is less actively supported these days), or worse "faking varargs" by adding enough "optional" args in the hopes things will work out, those functions were converted to use the `<stdarg.h>` mechanism.  Typically this involved declaring a `va_list ap` at the start of the function, then calling `va_start (ap, some_arg)` as the first action of the function, and then calling `va_end (ap)` before every return in that function.  In a few cases, a call to `sprintf(3)` had to be replaced with a call to `vsprintf()`.

In a few cases, a standard C "_<something.h>_" include had to be added in order to properly declare a standard libc function.

The gcc compiler objected to how the code "skip(ped) backward over blanks and nulls" on the last line of the virtual 24x80 screen because the code would step beyond the static `screen` 2D array, and the code was capable of clobbering memory beyond the last line: potentially going into previous lines and in theory even father back before the `screen` 2D array while blanks or NUL bytes were found. This code was fixed in order to satisfy a gcc compiler warning.

For code of the form `if (retc = ioctl (READ, FIONREAD, &n)) { ... }`, the clang compiler raised warnings of the form:

> place parentheses around the assignment to silence this warning

Such code was converted into code of the form:

```c
      retc = ioctl (READ, FIONREAD, &n);
      if (retc) {
         ...
      }
```

For code of the form `while (monc = *genocide) { ... }`, we silenced the warning by using `while ((monc = *genocide_) { ... }` instead.

In a few cases for clang, a `time_t *` value was assumed to be formatted (via `sscanf(3)` and `fprintf(3)`) as an `int *` instead of a `long *`. This is likely to become a problem for `rogomatic(6)` after **2038 Jan 18**. This was fixed by using a format using `%ld` instead of `%d`.

In one case for clang, a format of `%0.4s` was used where the flag '0' results in undefined behavior with 's' conversion specifier.  For the `%s` format specifier, zero padding isn't defined in the standard. In that case, the format was changed to use `%.4s`.

The clang compiler found cases where there was multiple un-sequenced modifications of a variable in an expression.  This can lead to undefined behavior, as the compiler cannot guarantee which modification takes precedence.  This could lead to `rogomatic(6)` behaving differently when compiled under different compilers and/or different situations.

The clang compiler found `fprintf(3)` statements with the wrong number of args according to the format string.

The clang compiler issued **strong** warnings about the use of the `mktemp(3)` function: that the use of `mktemp(3)` deprecated to security concerns inherent in the design of that libc function.  The code was modified to use `mkstemp(3)` instead.

The `register` was also removed.  In some compilers, this can result in less optimal code.  Today it is much better to let the C optimizer do its job.  In most compiles today the `register` attribute is ignored. Removing the `register` attribute does not impact how the C code executes **AND** it allows the C optimizer do its job.

Trailing whitespace (found in a few places) was moved, was cases where ASCII space was put before an ASCII tab.

The order of include files was made consistent.  In particular system include files were included first in whatever order the code had originally followed in new system include files that were needed to satisfy libc function declarations.  Then a blank line followed by `rogomatic(6)` include files where `types.h` was always first, then if needed `globals.h` was included next, followed by `install.h` if that was needed, follow by as neeed `termtokens.h`, and finally `getroguetoken.h` as needed.

Great care was made to be sure that the changes to the C source did **NOT** change how `rogomatic(6)` works.  Nevertheless in cases where the C compiler might produce defined results, execution might change for the better or worse.  Overall, the upgrade to C code to conform to gnu17/ISO C17 is a significant improvement to this `rogomatic(6)` code repository.

This Pull Request maintains the C code style of `rogomatic(6)`.

This Pull Request was tested on:

* Red Hat Enterprise Linux release 9.6 (Plow)
* gcc version 11.5.0 20240719 (Red Hat 11.5.0-5) (GCC)

* macOS 15.5 Apple clang version 17.0.0 (clang-1700.0.13.3)
* clang version 17.0.0 (clang-1700.0.13.3)

The `rogomatic(6)` program was tested with [lcn2 rogue5.4 repo](https://github.com/lcn2/rogue5.4), which compares favorably with the rogue 5.4 code found under [`rogomatic(6)`/archives/rogue](https://github.com/flowerbug/rogomatic/tree/master/archives/rogue). By favorably I mean that the [rogue5.4 repo form lcn2](https://github.com/lcn2/rogue5.4) includes an update C code to conform to gnu17/ISO C17 w/o errors and warning, some important rogue5.4 portability fixes for BSD, Linux and macOS based systems, all bug fixes found in the `rogomatic(6)` archive, a few more important bug fixes found in other rogue5.4 repos, an **MOST IMPORTANTLY** some additional bug fixes to prevent `rogue(6)` from crashing: especially under `rogomatic(6)` stress conditions! In all other cases, the `rogue(6)` game behaves the same way as the classic `rogue(6)` game that ran under BSD Unix and for which the classic `rogomatic(6)` "of that day" could run for days (serving as a system load test).  For more information on our test case, see [README.md from lcn2 rogue5.4 repo](https://github.com/lcn2/rogue5.4/blob/master/README.md).

There **ARE ISSUES** with `rogomatic(6)` that remain after this Pull Request. Among the issues are:

- macOS does not allow one to create `/var/games` so `rogomatic(6)` will not function
- `rogomatic(6)` and problems managing orphan rogue process children
- `rogomatic(6)` has buffer overflow problems
- `rogomatic(6)` has memory leaks
- building `rogomatic(6)` is not straightforward, lacks a top level `Makefile` and `.gitignore`
- `rogomatic(6)` other bugs that will likely cause it to crash
- etc.

The interprocess management between rogomatic(6) and rogue(6) appears to have problems. Zombie "you died" rogue games don't clean up, rogomatic doesn't automatically fire up a new game to try again in some cases, etc. So while the code may be error and warning free on gcc and clang, I would not call rogomatic stable just yet.

Those issues will be address in [lcn2 clone of flowerbug's rogomatic repo](https://github.com/lcn2/rogomatic). **PLEASE SEE THAT REPO FOR A MORE COMPREHENSIVE FIX**.

I hope these changes both preserve the original intent of the C code **AND** allow future C compiles to be able to compile `rogomatic(6)` without error and warnings.